### PR TITLE
[add] ユーザ作成と同時にマイページを作成する機能を追加

### DIFF
--- a/accounts/adapter.py
+++ b/accounts/adapter.py
@@ -11,7 +11,7 @@ class CustomAccountAdapter(DefaultAccountAdapter):
     """アカウントユーザのアダプタクラス"""
 
     def save_user(self, request, user, form, commit=True):
-        """save_userをオーバライド→ユーザ保存時の処理を定義"""
+        """allauthのsave_userを再定義→ユーザ保存時の処理を追加"""
 
         data = form.cleaned_data
         username = data.get('username')

--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -5,6 +5,8 @@ from django.utils.translation import gettext_lazy as _
 from .models import CustomUser
 
 class CustomUserAdmin(UserAdmin):
+    """管理画面の表示する項目を設定"""
+
     list_display = ('usernonamae', 'id', 'username','email','age','sex','is_staff')
 
     fieldsets = (

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -3,6 +3,8 @@ from django import forms
 from .models import CustomUser
 
 class MyCustomSignupForm(SignupForm):
+    """サインアップ時のフォーム"""
+
     username = forms.CharField(label='ID', required=True, widget=forms.TextInput(attrs={'placeholder':'taro1225'}))
     usernonamae = forms.CharField(label='ユーザ名', required=True, widget=forms.TextInput(attrs={'placeholder':'太郎'}))
     email = forms.EmailField(label='メールアドレス', required=True, widget=forms.TextInput(attrs={'placeholder':'taro@example.com'}))
@@ -11,12 +13,7 @@ class MyCustomSignupForm(SignupForm):
     born_at = forms.DateField(label='生年月日', required=False, widget=forms.SelectDateWidget(years=range(1900,2021)))
 
     def save(self, request):
+        """保存する動作はアダプタークラスへ"""
 
-        # Ensure you call the parent class's save.
-        # .save() returns a User object.
         user = super(MyCustomSignupForm, self).save(request)
-
-        # Add your own processing here.
-
-        # You must return the original result.
         return user

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -8,7 +8,7 @@ def get_iconimage_path(instance, filename):
     return 'images/{0}/iconimage/{1}'.format(instance.id, filename)
 
 class CustomUser(AbstractUser):
-    ''' 拡張ユーザーモデル '''
+    """拡張ユーザーモデル"""
 
     class Meta(AbstractUser.Meta):
         db_table = 'custom_user'

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,35 @@
+from django.urls import path, re_path
+from allauth.account import views
+from . import views as views_custom
+
+"""allauthのルーティング設定をすべて記述することによって
+   パッケージのviewsを部分的にイジることができる。"""
+
+urlpatterns = [
+    path("signup/", views.signup, name="account_signup"),
+    path("login/", views.login, name="account_login"),
+    path("logout/", views.logout, name="account_logout"),
+    path("password/change/", views.password_change,
+         name="account_change_password"),
+    path("password/set/", views.password_set, name="account_set_password"),
+    path("inactive/", views.account_inactive, name="account_inactive"),
+
+    # E-mail
+    path("email/", views.email, name="account_email"),
+    path("confirm-email/", views.email_verification_sent,
+         name="account_email_verification_sent"),
+    # vies_custom.confirm_emailとしている。
+    re_path(r"^confirm-email/(?P<key>[-:\w]+)/$", views_custom.confirm_email,
+            name="account_confirm_email"),
+
+    # password reset
+    path("password/reset/", views.password_reset,
+         name="account_reset_password"),
+    path("password/reset/done/", views.password_reset_done,
+         name="account_reset_password_done"),
+    re_path(r"^password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$",
+            views.password_reset_from_key,
+            name="account_reset_password_from_key"),
+    path("password/reset/key/done/", views.password_reset_from_key_done,
+         name="account_reset_password_from_key_done"),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,48 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from apiv1.models import Mypage
+from apiv1.forms import MypageForm
+from allauth.account.views import ConfirmEmailView
+from allauth.account.adapter import get_adapter
+from django.contrib import messages
+from allauth.account import app_settings
 
-# Create your views here.
+
+class CustomConfirmEmailView(ConfirmEmailView):
+    """メールアドレス本確認のallauthパッケージを継承"""
+
+    def post(self, *args, **kwargs):
+        """POST時にマイページ生成機能を追加"""
+        
+        user = self.request.user
+        data = {}
+        data['user'] = user
+        mypage = MypageForm(data)
+        # バリデーションで同一ユーザーのマイページの複製を回避
+        if mypage.is_valid():
+            mypage.save()
+
+        self.object = confirmation = self.get_object()
+        confirmation.confirm(self.request)
+        get_adapter(self.request).add_message(
+            self.request,
+            messages.SUCCESS,
+            'account/messages/email_confirmed.txt',
+            {'email': confirmation.email_address.email})
+        if app_settings.LOGIN_ON_EMAIL_CONFIRMATION:
+            resp = self.login_on_confirm(confirmation)
+            if resp is not None:
+                return resp
+        # Don't -- allauth doesn't touch is_active so that sys admin can
+        # use it to block users et al
+        #
+        # user = confirmation.email_address.user
+        # user.is_active = True
+        # user.save()
+        redirect_url = self.get_redirect_url()
+        if not redirect_url:
+            ctx = self.get_context_data()
+            return self.render_to_response(ctx)
+        return redirect(redirect_url)
+
+
+confirm_email = CustomConfirmEmailView.as_view()

--- a/apiv1/forms.py
+++ b/apiv1/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+from .models import Mypage
+
+class MypageForm(forms.ModelForm):
+    """マイページ自動作成機能実装にあたり、is_valid()を使用するために作成"""
+
+    class Meta:
+        model = Mypage
+        fields = ['user', 'introduction', 'homeimage']

--- a/apiv1/models.py
+++ b/apiv1/models.py
@@ -6,12 +6,12 @@ def get_homeimage_path(instance, filename):
     return 'images/{0}/homeimage/{1}'.format(instance.user.id, filename)
 
 class Mypage(models.Model):
-    """マイページ"""
+    """マイページモデル"""
 
     class Meta:
         db_table = 'mypage'
     
-    user = models.ForeignKey(get_user_model(), verbose_name='ユーザ', on_delete=models.CASCADE, related_name='mypage_user')
+    user = models.OneToOneField(get_user_model(), verbose_name='ユーザ', unique=True, on_delete=models.CASCADE, related_name='mypage_user')
     introduction = models.CharField(verbose_name='自己紹介', max_length=150, blank=True, null=True)
     homeimage = models.ImageField(verbose_name='ホーム画像', blank=True, null=True, upload_to=get_homeimage_path)
     

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls.static import static
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),
-    path('accounts/', include('allauth.urls')),
+    path('accounts/', include('accounts.urls')),
     path('api/v1/', include('apiv1.urls')),
     path('test/', TemplateView.as_view(template_name='index.html'), name='index'),
 ]


### PR DESCRIPTION
詳しくはユーザを作成した時の、メールアドレス認証の際にモデルを作成できるようにしました。
バリデーションで同ユーザが1つ以上マイページを作ることができないようになっています。