### PR TITLE
[add] 投稿の削除＆投票情報更新＆投票済み一覧表示のテストを追加！

### DIFF
--- a/apiv1/tests/test_views.py
+++ b/apiv1/tests/test_views.py
@@ -153,6 +153,7 @@ class TestMypageAPIView(APITestCase):
         self.assertJSONEqual(response.content, expected_json_dict)
 
 
+# (正常系)2methods,(異常系)2methods,(合計)4methods.
 class TestMypageVotedListAPIView(APITestCase):
     """MypageVotedListAPIViewのテストクラス"""
 
@@ -281,6 +282,33 @@ class TestMypageVotedListAPIView(APITestCase):
 
         response = self.client.get(self.TARGET_URL_WITH_PK.format(self.user2.username))
         self.assertEqual(response.status_code, 204)
+
+    def test_get_voted_posts_unauthorized(self):
+        """ユーザーモデルの投票済みの投稿一覧取得APIへのGETリクエスト(異常系:ヘッダーにトークンがのっていない時)"""
+
+        # あえてヘッダーにトークンを載せない
+
+        response = self.client.get(self.TARGET_URL_WITH_PK.format(self.user2.username))
+        self.assertEqual(response.status_code, 401)
+
+        expected_json_dict = {
+            "detail": "認証情報が含まれていません。"
+        }
+        self.assertJSONEqual(response.content, expected_json_dict)
+
+    def test_get_voted_posts_not_found(self):
+        """ユーザーモデルの投票済みの投稿一覧取得APIへのGETリクエスト(異常系:リクエストしたエンドポイントのユーザーIDが存在しない時)"""
+
+        token = str(RefreshToken.for_user(self.user1).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
+
+        response = self.client.get(self.TARGET_URL_WITH_PK.format('user3'))
+        self.assertEqual(response.status_code, 404)
+
+        expected_json_dict = {
+            'detail':'存在しないユーザーIDです'
+        }
+        self.assertJSONEqual(response.content, expected_json_dict)
 
 
 # (正常系)2methods,(異常系)3methods,(合計)5methods.

--- a/apiv1/tests/test_views.py
+++ b/apiv1/tests/test_views.py
@@ -637,6 +637,57 @@ class TestPostUpdateAPIView(APITestCase):
         }
         self.assertJSONEqual(response.content, expected_json_dict)
 
+    def test_get_update_posts_no_voted_success(self):
+        """投稿モデルの投票情報更新APIへのGETリクエスト(正常系:投票していないユーザーは投票結果閲覧不可)"""
+
+        # 投稿用のユーザーがログイン→投稿
+        token = str(RefreshToken.for_user(self.user1).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
+        params = {
+            'question':'あなたの推しメンは？',
+            'options':[{
+                'select_num':0,
+                'answer':'齋藤飛鳥'
+            },{
+                'select_num':1,
+                'answer':'北野日奈子'
+            }]
+        }
+        self.client.post('/api/v1/posts/', params, format='json')
+        
+        # 他ユーザーにてログイン→投稿情報更新
+        token = str(RefreshToken.for_user(self.user2).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
+        
+        post = Post.objects.get()
+        response = self.client.get(self.TARGET_URL_WITH_PK.format(post.id))
+        self.assertEqual(response.status_code, 200)
+        
+        options = Option.objects.filter(share_id=post.share_id)
+        options_list = []
+        for option in options:
+            option_dict = {}
+            option_dict['select_num'] = option.select_num
+            option_dict['answer'] = option.answer
+            option_dict['votes'] = -1
+            options_list.append(option_dict)
+        post_created_at = str(post.created_at)
+        hours = timedelta(hours=9)
+        utc_created_at = datetime.strptime(post_created_at, '%Y-%m-%d %H:%M:%S.%f%z')
+        created_at = utc_created_at + hours
+        expected_json_dict = {
+            'post_id':str(post.id),
+            'user_id':str(post.user.username),
+            'iconimage':circleci.MEDIA_URL + str(post.user.iconimage),
+            'question':post.question,
+            'created_at':created_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            'voted':False,
+            'selected_num':-1,
+            'total':0,
+            'options':options_list
+        }
+        self.assertJSONEqual(response.content, expected_json_dict)
+
 
 # (正常系)1method,(異常系)3methods,(合計)4methods.
 class TestPollCreateAPIView(APITestCase):

--- a/apiv1/tests/test_views.py
+++ b/apiv1/tests/test_views.py
@@ -880,7 +880,6 @@ class TestPostUpdateAPIView(APITestCase):
     def test_get_update_posts_not_found(self):
         """投稿モデルの投票情報更新APIへのGETリクエスト(異常系:投稿に投票したが投稿IDが存在しない時)"""
 
-        # 投稿用のユーザーがログイン
         token = str(RefreshToken.for_user(self.user1).access_token)
         self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
 
@@ -895,9 +894,6 @@ class TestPostUpdateAPIView(APITestCase):
             }]
         }
         self.client.post('/api/v1/posts/', params, format='json')
-        
-        token = str(RefreshToken.for_user(self.user2).access_token)
-        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
 
         changed_pid = str(uuid.uuid4())
         response = self.client.get(self.TARGET_URL_WITH_PK.format(changed_pid))

--- a/apiv1/tests/test_views.py
+++ b/apiv1/tests/test_views.py
@@ -718,6 +718,37 @@ class TestPostUpdateAPIView(APITestCase):
             "detail": "認証情報が含まれていません。"
         }
         self.assertJSONEqual(response.content, expected_json_dict)
+    
+    def test_get_update_posts_not_found(self):
+        """投稿モデルの投票情報更新APIへのGETリクエスト(異常系:投稿に投票したが投稿IDが存在しない時)"""
+
+        # 投稿用のユーザーがログイン
+        token = str(RefreshToken.for_user(self.user1).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
+
+        params = {
+            'question':'あなたの推しメンは？',
+            'options':[{
+                'select_num':0,
+                'answer':'齋藤飛鳥'
+            },{
+                'select_num':1,
+                'answer':'北野日奈子'
+            }]
+        }
+        self.client.post('/api/v1/posts/', params, format='json')
+        
+        token = str(RefreshToken.for_user(self.user2).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
+
+        changed_pid = str(uuid.uuid4())
+        response = self.client.get(self.TARGET_URL_WITH_PK.format(changed_pid))
+        self.assertEqual(response.status_code, 404)
+
+        expected_json_dict = {
+            "detail":"存在しない投稿IDです。"
+        }
+        self.assertJSONEqual(response.content, expected_json_dict)
 
 
 # (正常系)1method,(異常系)3methods,(合計)4methods.

--- a/apiv1/tests/test_views.py
+++ b/apiv1/tests/test_views.py
@@ -376,6 +376,59 @@ class TestPostCreateAPIView(APITestCase):
         self.assertJSONEqual(response.content, expected_json_dict)
 
 
+# (正常系)1method,(異常系)2methods,(合計)3methods.
+class PostDeleteAPIView(APITestCase):
+    """PostDetailDeleteAPIViewのテストクラス"""
+
+    TARGET_URL_WITH_PK = '/api/v1/posts/{}/'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user1 = get_user_model().objects.create_user(
+            email='user1@example.com',
+            username='user1',
+            password='secret',
+            usernonamae='サンプル1',
+            sex='0',
+            age=21,
+            born_at='1998-08-10',
+        )
+        cls.user2 = get_user_model().objects.create_user(
+            email='user2@example.com',
+            username='user2',
+            password='secret',
+            usernonamae='サンプル2',
+            sex='1',
+            age=19,
+            born_at='2001-12-02',
+        )
+
+    def test_delete_posts_success(self):
+        """投稿モデルの削除APIへのDELETEリクエスト(正常系)"""
+
+        token = str(RefreshToken.for_user(self.user1).access_token)
+        self.client.credentials(HTTP_AUTHORIZATION='JWT ' + token)
+
+        params = {
+            'question':'あなたの推しメンは？',
+            'options':[{
+                'select_num':0,
+                'answer':'齋藤飛鳥'
+            },{
+                'select_num':1,
+                'answer':'北野日奈子'
+            }]
+        }
+        self.client.post('/api/v1/posts/', params, format='json')
+
+        post = Post.objects.get()
+        response = self.client.delete(self.TARGET_URL_WITH_PK.format(post.id))
+
+        self.assertEqual(Post.objects.count(), 0)
+        self.assertEqual(response.status_code, 204)
+
+
 # (正常系)1method,(異常系)3methods,(合計)4methods.
 class TestPollCreateAPIView(APITestCase):
     """PollCreateAPIViewのテストクラス"""

--- a/apiv1/tests/test_views.py
+++ b/apiv1/tests/test_views.py
@@ -485,7 +485,7 @@ class TestPostDeleteAPIView(APITestCase):
         self.assertJSONEqual(response.content, expected_json_dict)
 
 
-# (正常系)3methods,(異常系)methods,(合計)methods.
+# (正常系)3methods,(異常系)2methods,(合計)5methods.
 class TestPostUpdateAPIView(APITestCase):
     """PostUpdateAPIViewのテストクラス"""
 

--- a/apiv1/views.py
+++ b/apiv1/views.py
@@ -74,19 +74,19 @@ class MypagePostedListAPIView(views.APIView):
     def get(self, request, pk, *args, **kwargs):
         """自分の投稿取得(一覧)"""
 
-        if request.user.username != pk:
-            return Response({}, status.HTTP_204_NO_CONTENT)
-        
-        sk = get_user_model().objects.get(username=pk).id
+        user = get_user_model().objects.filter(username=pk)
+        if len(user) == 0:
+            return Response({'detail':'存在しないユーザーIDです'}, status.HTTP_404_NOT_FOUND)
+        user_id = user[0].id
 
         # 自身の投稿のみフィルタリング
         if 'pid' in request.GET:
             post_basis = Post.objects.get(id=request.GET['pid'])
-            querysets = Post.objects.filter(user_id=sk, created_at__lt=post_basis.created_at).order_by('-created_at')[:10]
+            querysets = Post.objects.filter(user_id=user_id, created_at__lt=post_basis.created_at).order_by('-created_at')[:10]
         else:
-            querysets = Post.objects.filter(user_id=sk).order_by('-created_at')[:10]
+            querysets = Post.objects.filter(user_id=user_id).order_by('-created_at')[:10]
 
-        serializer = PostListSerializer(instance=querysets, many=True, pk=sk)
+        serializer = PostListSerializer(instance=querysets, many=True, pk=user_id)
 
         for datas in serializer.data:
             if not datas['voted']:
@@ -101,7 +101,7 @@ class MypagePostedListAPIView(views.APIView):
             else:
                 total = 0
                 for data in datas['options']:
-                    flag = Poll.objects.filter(user_id=sk,option_id=data['id'])
+                    flag = Poll.objects.filter(user_id=user_id,option_id=data['id'])
                     if len(flag) > 0:
                         datas['selected_num'] = Option.objects.get(id=flag[0].option_id).select_num
                     else:

--- a/apiv1/views.py
+++ b/apiv1/views.py
@@ -125,7 +125,7 @@ class MypageVotedListAPIView(views.APIView):
         """自分の投票取得(一覧)"""
 
         if request.user.username != pk:
-            return Response({}, status.HTTP_204_NO_CONTENT)
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
         sk = get_user_model().objects.get(username=pk).id
 

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -195,9 +195,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES':[
         'rest_framework_simplejwt.authentication.JWTAuthentication'
     ],
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
-    ],
+    # 'DEFAULT_PERMISSION_CLASSES': [
+    #     'rest_framework.permissions.IsAuthenticated',
+    # ],
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
 

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -195,9 +195,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES':[
         'rest_framework_simplejwt.authentication.JWTAuthentication'
     ],
-    # 'DEFAULT_PERMISSION_CLASSES': [
-    #     'rest_framework.permissions.IsAuthenticated',
-    # ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
 


### PR DESCRIPTION
## 投稿の削除機能のテストを追加 #155 
- (正常)投稿へDELETEリクエスト[204 No Content]
- (異常)ヘッダーにトークンが乗っていないリクエスト[401 Unauthorized]
- (異常)DELTEリクエスト時にエンドポイントにて存在しない投稿IDを選択した時[404 Not Found]

## 投票情報更新機能のテストを追加 #157 
- (正常)投票済みユーザーなら投票結果閲覧可[200 OK]
- (正常)投稿ユーザーなら投票結果閲覧可。ただしselected_numは-1[200 OK]
- (正常)投票していないユーザーは投票結果閲覧不可[200 OK]
- (異常)ヘッダーにトークンが乗っていないリクエスト[401 Unauthorized]
- (異常)GETリクエスト時にエンドポイントで存在しない投稿IDがある時[404 Not Found]

## マイページにある投票済み表示一覧機能のテストを追加 #158 
- (正常)投票済み一覧はユーザー本人であれば返す[200 OK]
- (正常)マイページの投票済み一覧は他人には返さない[204 No Content]
- (異常)ヘッダーにトークンがのっていない時[401 Unauthorized]
- (異常)リクエストしたエンドポイントのユーザーIDが存在しない時[404 Not Found]

## Issues
Closes #155, Closes #157, Closes #158 