### PR TITLE
[add] OptionSerializerのテスト/Makefileの設定を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,9 @@ collectstatic:
 
 test:
 	docker-compose run --rm shappar-back python3 manage.py test --settings=config.settings.local
+
+test_views:
+	docker-compose run --rm shappar-back python3 manage.py test apiv1.tests.test_views --settings=config.settings.local
+
+test_serializers:
+	docker-compose run --rm shappar-back python3 manage.py test apiv1.tests.test_serializers --settings=config.settings.local

--- a/apiv1/serializers.py
+++ b/apiv1/serializers.py
@@ -5,13 +5,12 @@ from .models import Post, Poll, Option
 class MypageSerializer(serializers.ModelSerializer):
     """マイページ用シリアライザ"""
 
-    unique_id = serializers.ReadOnlyField(source='id')
     user_id = serializers.CharField(source='username')
     name = serializers.CharField(source='usernonamae')
 
     class Meta:
         model = get_user_model()
-        fields = ['unique_id', 'user_id', 'name', 'introduction', 'iconimage', 'homeimage']
+        fields = ['user_id', 'name', 'introduction', 'iconimage', 'homeimage']
 
 
 class OptionSerializer(serializers.ModelSerializer):

--- a/apiv1/tests/test_serializer.py
+++ b/apiv1/tests/test_serializer.py
@@ -63,3 +63,32 @@ class TestOptionSerializer(TestCase):
         input_data['answer'] = 'テスト'
         del input_data['share_id']
         self.change_required(input_data, 'share_id')
+
+
+    def test_input_invalid_answer_shareid_are_blank(self):
+        """入力データのバリデーション(NG:answerやshare_idが空文字)"""
+
+        input_data = {
+            'select_num':0,
+            'answer':'',
+            'votes':3,
+            'share_id':uuid.uuid4()
+        }
+        serializer = OptionSerializer(data=input_data)
+
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertCountEqual(serializer.errors.keys(), ['answer'])
+        self.assertCountEqual(
+            [x.code for x in serializer.errors['answer']],
+            ['blank'],
+        )
+
+        input_data['answer'] = 'テスト'
+        input_data['share_id'] = ''
+        serializer_share_id = OptionSerializer(data=input_data)
+        self.assertEqual(serializer_share_id.is_valid(), False)
+        self.assertCountEqual(serializer_share_id.errors.keys(), ['share_id'])
+        self.assertCountEqual(
+            [x.code for x in serializer_share_id.errors['share_id']],
+            ['invalid'],
+        )

--- a/apiv1/tests/test_serializer.py
+++ b/apiv1/tests/test_serializer.py
@@ -1,0 +1,33 @@
+import uuid
+from django.test import TestCase
+from django.utils.timezone import localtime
+from django.core.files import File
+
+from django.contrib.auth import get_user_model
+from apiv1.models import Post, Poll, Option
+from apiv1.serializers import (
+    PostCreateSerializer, 
+    PostListSerializer, 
+    PollSerializer, 
+    OptionSerializer,
+    PostDetailSerializer,
+)
+
+# (正常系)2methods,(異常系)2methods,(合計)4methods.
+class TestOptionSerializer(TestCase):
+    """OptionSerializerのテストクラス"""
+
+    def test_input_valid(self):
+        """入力データのバリデーション(OK)"""
+
+        # シリアライザを作成
+        input_data = {
+            'select_num':1,
+            'answer':'テスト',
+            'votes':3,
+            'share_id':uuid.uuid4()
+        }
+        serializer = OptionSerializer(data=input_data)
+
+        # バリデーションの結果を検証
+        self.assertEqual(serializer.is_valid(), True)

--- a/apiv1/tests/test_serializer.py
+++ b/apiv1/tests/test_serializer.py
@@ -17,6 +17,17 @@ from apiv1.serializers import (
 class TestOptionSerializer(TestCase):
     """OptionSerializerのテストクラス"""
 
+    def change_required(self, input_data, field):
+        """何度も使う処理を関数化(method:test_input_invalid_something_is_required)"""
+
+        serializer = OptionSerializer(data=input_data)
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertCountEqual(serializer.errors.keys(), [field])
+        self.assertCountEqual(
+            [x.code for x in serializer.errors[field]],
+            ['required'],
+        )
+
     def test_input_valid(self):
         """入力データのバリデーション(OK)"""
 
@@ -31,3 +42,24 @@ class TestOptionSerializer(TestCase):
 
         # バリデーションの結果を検証
         self.assertEqual(serializer.is_valid(), True)
+
+    def test_input_invalid_something_is_required(self):
+        """入力データのバリデーション(NG:何かがリクエストされていない)"""
+
+        input_data = {
+            'select_num': 0,
+            'answer':'テスト',
+            'votes':3,
+            'share_id':uuid.uuid4()
+        }
+        del input_data['select_num']
+        # 事前に定義した関数を実行
+        self.change_required(input_data, 'select_num')
+
+        input_data['select_num'] = 0
+        del input_data['answer']
+        self.change_required(input_data, 'answer')
+
+        input_data['answer'] = 'テスト'
+        del input_data['share_id']
+        self.change_required(input_data, 'share_id')

--- a/apiv1/tests/test_serializer.py
+++ b/apiv1/tests/test_serializer.py
@@ -92,3 +92,22 @@ class TestOptionSerializer(TestCase):
             [x.code for x in serializer_share_id.errors['share_id']],
             ['invalid'],
         )
+
+    def test_output_data(self):
+        """出力データの内容検証"""
+
+        option = Option.objects.create(
+            select_num=0,
+            answer='テスト',
+            share_id=uuid.uuid4()
+        )
+        serializer = OptionSerializer(instance=option)
+
+        expected_data = {
+            'id':option.id,
+            'select_num':option.select_num,
+            'answer':option.answer,
+            'votes':option.votes,
+            'share_id':str(option.share_id)
+        }
+        self.assertDictEqual(serializer.data, expected_data)

--- a/apiv1/tests/test_serializers.py
+++ b/apiv1/tests/test_serializers.py
@@ -13,7 +13,7 @@ from apiv1.serializers import (
     PostDetailSerializer,
 )
 
-# (正常系)2methods,(異常系)2methods,(合計)4methods.
+# (正常系)2methods,(異常系)3methods,(合計)5methods.
 class TestOptionSerializer(TestCase):
     """OptionSerializerのテストクラス"""
 
@@ -91,6 +91,24 @@ class TestOptionSerializer(TestCase):
         self.assertCountEqual(
             [x.code for x in serializer_share_id.errors['share_id']],
             ['invalid'],
+        )
+
+    def test_input_invalid_answer_over(self):
+        """入力データのバリデーション(NG:answerが文字数制限を超える)"""
+
+        input_data = {
+            'select_num':0,
+            'answer':'テストテストテストテストテストテストテストテストテストテストテストテストテストテスト',
+            'votes':3,
+            'share_id':uuid.uuid4()
+        }
+        serializer = OptionSerializer(data=input_data)
+
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertCountEqual(serializer.errors.keys(), ['answer'])
+        self.assertCountEqual(
+            [x.code for x in serializer.errors['answer']],
+            ['max_length'],
         )
 
     def test_output_data(self):

--- a/apiv1/views.py
+++ b/apiv1/views.py
@@ -33,9 +33,7 @@ class MypageAPIView(views.APIView):
 
         mypage = get_object_or_404(get_user_model(), username=pk)
         serializer = MypageSerializer(instance=mypage)
-        response = serializer.data
-        del response['unique_id']
-        return Response(response, status.HTTP_200_OK)
+        return Response(serializer.data, status.HTTP_200_OK)
 
     def put(self, request, pk, *args, **kwargs):
         """マイページモデルの更新APIに対応するハンドラメソッド"""
@@ -48,9 +46,7 @@ class MypageAPIView(views.APIView):
         serializer = MypageSerializer(instance=mypage, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        response = serializer.data
-        del response['unique_id']
-        return Response(response, status.HTTP_200_OK)
+        return Response(serializer.data, status.HTTP_200_OK)
 
     def patch(self, request, pk, *args, **kwargs):
         """マイページモデルの一部更新APIに対応するハンドラメソッド"""
@@ -63,9 +59,7 @@ class MypageAPIView(views.APIView):
         serializer = MypageSerializer(instance=mypage, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        response = serializer.data
-        del response['unique_id']
-        return Response(response, status.HTTP_200_OK)
+        return Response(serializer.data, status.HTTP_200_OK)
 
 
 class MypagePostedListAPIView(views.APIView):


### PR DESCRIPTION
## OptionSerializerのテストを追加 #159 
- (正常)入力データのバリデーション
- (異常)何かのパラメータがリクエストされていない
- (異常)パラメータに存在してはならない空文字が存在する
- (異常)`answer`の文字数制限を超える
- (正常)出力データの内容検証

## Makefileに単体テストのコマンドを追加 #160 
###以下の３種が存在している
- `make test`
- `make test_views`
- `make test_serializer`

## 不必要なレスポンスのパラメータ削除 #161 
- マイページ取得時にユーザーのuuidは不必要

## Issue
Closes #159, Closes #160, Closes #161 