### PR TITLE
[add] CircleCIによる静的ファイルのS3へ自動デプロイ機能の追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,14 @@ jobs:
                 from: static/css
                 to: 's3://${AWS_STORAGE_BUCKET_NAME}/static/css'
                 overwrite: true
+    js_deploy:
+        executor: shappar_static
+        steps:
+            - checkout
+            - aws-s3/sync:
+                from: static/js
+                to: 's3://${AWS_STORAGE_BUCKET_NAME}/static/js'
+                overwrite: true
 
 workflows:
     version: 2
@@ -148,6 +156,10 @@ workflows:
     static_deploy:
         jobs:
             - css_deploy:
+                filters:
+                    branches:
+                        only: master
+            - js_deploy:
                 filters:
                     branches:
                         only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@ description: "Djangoサーバーの起動とマイグレーション＆自動デ
 orbs:
     aws-ecr: circleci/aws-ecr@6.7.1
     aws-ecs: circleci/aws-ecs@1.1.0
+    aws-s3: circleci/aws-s3@1.0.15
 
 executors:
-    build-test:
+    shappar_django:
         working_directory: ~/Shappar
         docker:
             - image: circleci/python:3.8.1
@@ -19,6 +20,10 @@ executors:
                 POSTGRES_USER: postgres
                 POSTGRES_PASSWORD: postgres
                 TZ: Asia/Tokyo
+    shappar_static:
+        working_directory: ~/Shappar
+        docker:
+            - image: circleci/python:3.8.1
 
 commands:
     chown_python_package:
@@ -68,8 +73,8 @@ commands:
                 command: python3 manage.py test --settings=config.settings.circleci
 
 jobs:
-    shappar-build-test:
-        executor: build-test
+    build_test:
+        executor: shappar_django
         steps:
             - checkout
             - chown_python_package
@@ -78,16 +83,26 @@ jobs:
             - save_python_package
             - db_migrations
             - run_test
+    css_deploy:
+        executor: shappar_static
+        steps:
+            - checkout
+            - aws-s3/sync:
+                from: static/css
+                to: 's3://${AWS_STORAGE_BUCKET_NAME}/static/css'
+                overwrite: true
 
 workflows:
     version: 2
+    # Djangoのテスト
     test:
         jobs:
-            - shappar-build-test:
+            - build_test:
                 filters:
                     branches:
                         ignore: master
-    back-deploy:
+    # DjangoをECR/ECSへデプロイ
+    back_deploy:
         jobs:
             - aws-ecr/build-and-push-image:
                 account-url: AWS_ECR_ACCOUNT_URL
@@ -107,7 +122,8 @@ workflows:
                 cluster-name: '${MY_APP_PREFIX}-cluster-v2'
                 service-name: '${MY_APP_PREFIX}-service-v2'
                 container-image-name-updates: 'container=shappar-back,tag=${CIRCLE_SHA2}'
-    nginx-deploy:
+    # NginxをECR/ECSへデプロイ
+    nginx_deploy:
         jobs:
             - aws-ecr/build-and-push-image:
                 account-url: AWS_ECR_ACCOUNT_URL
@@ -128,3 +144,10 @@ workflows:
                 cluster-name: '${MY_APP_PREFIX}-cluster-v2'
                 service-name: '${MY_APP_PREFIX}-service-v2'
                 container-image-name-updates: 'container=shappar-nginx,tag=${CIRCLE_SHA2}'
+    # 静的ファイル(CSS/JS)をS3へデプロイ
+    static_deploy:
+        jobs:
+            - css_deploy:
+                filters:
+                    branches:
+                        only: master


### PR DESCRIPTION
# AmazonS3への自動でデプロイ機能
## AmazonS3へファイルを自動であげる機能について #187 
- 前々からECS/ECRは自動なのに、S3に関しては自動でないことに疑問を持っていた。

## CircleCIを用いた静的ファイルの自動デプロイ機能について #186 
- CircleCIを用いればデプロイできることに気付く
- Orbsのバージョンはコチラを採用→`aws-s3: circleci/aws-s3@1.0.15`
- 同期によるデプロイなので、デプロイ前のファイルは消えてしまうので注意が必要

## Issues
Closes #186, Closes #187 