### PR TITLE
投稿作成時のシリアライザのテストを追加！

### DIFF
--- a/apiv1/serializers.py
+++ b/apiv1/serializers.py
@@ -42,8 +42,14 @@ class PostCreateSerializer(serializers.ModelSerializer):
         post.options.set(options)
         return post
 
+    def validate_options(self, value):
+        """複数の選択肢(options)が2つ以上存在しないことを阻止バリデーションメソッド"""
+        if len(value) < 2:
+            raise serializers.ValidationError("選択肢は2つ以上にしてください。")
+        return value
+
     def validate(self, data):
-        """同じ投稿への複数投票&投稿本人の投票阻止バリデーションメソッド"""
+        """選択肢間and選択肢-投稿間でshare_idが非共通化阻止バリデーションメソッド"""
         options = data.get('options')
         share_id = data.get('share_id')
 

--- a/apiv1/serializers.py
+++ b/apiv1/serializers.py
@@ -42,6 +42,21 @@ class PostCreateSerializer(serializers.ModelSerializer):
         post.options.set(options)
         return post
 
+    def validate(self, data):
+        """同じ投稿への複数投票&投稿本人の投票阻止バリデーションメソッド"""
+        options = data.get('options')
+        share_id = data.get('share_id')
+
+        option_share_id = options[0]['share_id']
+        for option in options:
+            if option_share_id != option['share_id']:
+                raise serializers.ValidationError("選択肢間でshare_idが共通ではありません")
+
+        if option_share_id != share_id:
+            raise serializers.ValidationError("投稿と選択肢のshare_idが共通ではありません")
+        
+        return data
+
 
 class PostPatchSerializer(serializers.ModelSerializer):
     """投票による投稿の合計投票数の変化用シリアライザ"""

--- a/apiv1/tests/test_serializers.py
+++ b/apiv1/tests/test_serializers.py
@@ -169,3 +169,36 @@ class TestPostCreateSerializer(TestCase):
         serializer = PostCreateSerializer(data=input_data)
         # バリデーションの結果を検証
         self.assertEqual(serializer.is_valid(), True)
+
+    def test_input_invalid_unshared_options(self):
+        """PostCreateSerializerの入力データのバリデーション(NG: 選択肢間でshare_idが共通でない)"""
+
+        share_id = uuid.uuid4()
+        data1 = {
+            'select_num': 0,
+            'answer': 'テスト1',
+            'votes': 1,
+            'share_id': share_id
+        }
+        data2 = {
+            'select_num': 1,
+            'answer': 'テスト2',
+            'votes': 2,
+            'share_id': uuid.uuid4()
+        }
+
+        # シリアライズ
+        input_data = {
+            'user': get_user_model().objects.get().id,
+            'question': 'テストだよ〜',
+            'options': [data1, data2],
+            'share_id': share_id
+        }
+        serializer = PostCreateSerializer(data=input_data)
+        # バリデーションの結果を検証
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertCountEqual(serializer.errors.keys(), ['non_field_errors'])
+        self.assertCountEqual(
+            [x.code for x in serializer.errors['non_field_errors']],
+            ['invalid'],
+        )

--- a/apiv1/tests/test_serializers.py
+++ b/apiv1/tests/test_serializers.py
@@ -1,8 +1,11 @@
 import uuid
 from django.test import TestCase
-
 from apiv1.models import Option
-from apiv1.serializers import OptionSerializer
+from apiv1.serializers import (
+    OptionSerializer,
+    PostCreateSerializer
+)
+from django.contrib.auth import get_user_model
 
 
 # (正常系)2methods,(異常系)3methods,(合計)5methods.
@@ -21,9 +24,9 @@ class TestOptionSerializer(TestCase):
         )
 
     def test_input_valid(self):
-        """入力データのバリデーション(OK)"""
+        """OptionSerializerの入力データのバリデーション(OK)"""
 
-        # シリアライザを作成
+        # シリアライズ
         input_data = {
             'select_num': 1,
             'answer': 'テスト',
@@ -31,12 +34,11 @@ class TestOptionSerializer(TestCase):
             'share_id': uuid.uuid4()
         }
         serializer = OptionSerializer(data=input_data)
-
         # バリデーションの結果を検証
         self.assertEqual(serializer.is_valid(), True)
 
     def test_input_invalid_something_is_required(self):
-        """入力データのバリデーション(NG:何かがリクエストされていない)"""
+        """OptionSerializerの入力データのバリデーション(NG:何かがリクエストされていない)"""
 
         input_data = {
             'select_num': 0,
@@ -57,7 +59,7 @@ class TestOptionSerializer(TestCase):
         self.change_required(input_data, 'share_id')
 
     def test_input_invalid_answer_shareid_are_blank(self):
-        """入力データのバリデーション(NG:answerやshare_idが空文字)"""
+        """OptionSerializerの入力データのバリデーション(NG:answerやshare_idが空文字)"""
 
         input_data = {
             'select_num': 0,
@@ -85,7 +87,7 @@ class TestOptionSerializer(TestCase):
         )
 
     def test_input_invalid_answer_over(self):
-        """入力データのバリデーション(NG:answerが文字数制限を超える)"""
+        """OptionSerializerの入力データのバリデーション(NG:answerが文字数制限を超える)"""
 
         input_data = {
             'select_num': 0,
@@ -103,7 +105,7 @@ class TestOptionSerializer(TestCase):
         )
 
     def test_output_data(self):
-        """出力データの内容検証"""
+        """OptionSerializerの出力データの内容検証(OK)"""
 
         option = Option.objects.create(
             select_num=0,
@@ -120,3 +122,50 @@ class TestOptionSerializer(TestCase):
             'share_id': str(option.share_id)
         }
         self.assertDictEqual(serializer.data, expected_data)
+
+
+# (正常系)1methods,(異常系)0methods,(合計)1methods.
+class TestPostCreateSerializer(TestCase):
+    """PostCreateSerializerのテストクラス"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user1 = get_user_model().objects.create_user(
+            email='user1@example.com',
+            username='user1',
+            password='secret',
+            usernonamae='サンプル1',
+            sex='0',
+            blood_type='0',
+            age=21,
+            born_at='1998-08-10',
+        )
+
+    def test_input_valid(self):
+        """PostCreateSerializerの入力データのバリデーション(OK)"""
+
+        share_id = uuid.uuid4()
+        data1 = {
+            'select_num': 0,
+            'answer': 'テスト1',
+            'votes': 1,
+            'share_id': share_id
+        }
+        data2 = {
+            'select_num': 1,
+            'answer': 'テスト2',
+            'votes': 2,
+            'share_id': share_id
+        }
+
+        # シリアライズ
+        input_data = {
+            'user': get_user_model().objects.get().id,
+            'question': 'テストだよ〜',
+            'options': [data1, data2],
+            'share_id': share_id
+        }
+        serializer = PostCreateSerializer(data=input_data)
+        # バリデーションの結果を検証
+        self.assertEqual(serializer.is_valid(), True)

--- a/apiv1/tests/test_serializers.py
+++ b/apiv1/tests/test_serializers.py
@@ -124,7 +124,7 @@ class TestOptionSerializer(TestCase):
         self.assertDictEqual(serializer.data, expected_data)
 
 
-# (正常系)1methods,(異常系)3methods,(合計)3methods.
+# (正常系)1methods,(異常系)4methods,(合計)5methods.
 class TestPostCreateSerializer(TestCase):
     """PostCreateSerializerのテストクラス"""
 
@@ -170,7 +170,7 @@ class TestPostCreateSerializer(TestCase):
         # バリデーションの結果を検証
         self.assertEqual(serializer.is_valid(), True)
     
-    def test_input_invalid_max_length(self):
+    def test_input_invalid_question_over(self):
         """PostCreateSerializerの入力データのバリデーション(NG: questionが150字より上)"""
 
         share_id = uuid.uuid4()
@@ -210,6 +210,37 @@ class TestPostCreateSerializer(TestCase):
         self.assertCountEqual(
             [x.code for x in serializer.errors['question']],
             ['max_length'],
+        )
+
+    # def test_input_invalid_required_id_blank(self):
+    #     """PostCreateSerializerの入力データのバリデーション(NG: 必須の入力データが存在しない時)"""
+    #     next
+    
+    def test_input_invalid_lesser_2_options(self):
+        """PostCreateSerializerの入力データのバリデーション(NG: 選択肢が2個未満だった時)"""
+        share_id = uuid.uuid4()
+        data1 = {
+            'select_num': 0,
+            'answer': 'テスト1',
+            'votes': 1,
+            'share_id': share_id
+        }
+
+        # シリアライズ(境界値もテストするよ！)
+        input_data = {
+            'user': get_user_model().objects.get().id,
+            'question': 'テストだよ〜！',
+            'options': [data1],
+            'share_id': share_id
+        }
+        serializer = PostCreateSerializer(data=input_data)
+        # バリデーションの結果を検証
+        self.assertEqual(serializer.is_valid(), False)
+        print(serializer.errors)
+        self.assertCountEqual(serializer.errors.keys(), ['options'])
+        self.assertCountEqual(
+            [x.code for x in serializer.errors['options']],
+            ['invalid'],
         )
 
     def test_input_invalid_unshared_options(self):

--- a/apiv1/tests/test_serializers.py
+++ b/apiv1/tests/test_serializers.py
@@ -124,7 +124,7 @@ class TestOptionSerializer(TestCase):
         self.assertDictEqual(serializer.data, expected_data)
 
 
-# (正常系)1methods,(異常系)0methods,(合計)1methods.
+# (正常系)1methods,(異常系)1methods,(合計)2methods.
 class TestPostCreateSerializer(TestCase):
     """PostCreateSerializerのテストクラス"""
 
@@ -193,6 +193,39 @@ class TestPostCreateSerializer(TestCase):
             'question': 'テストだよ〜',
             'options': [data1, data2],
             'share_id': share_id
+        }
+        serializer = PostCreateSerializer(data=input_data)
+        # バリデーションの結果を検証
+        self.assertEqual(serializer.is_valid(), False)
+        self.assertCountEqual(serializer.errors.keys(), ['non_field_errors'])
+        self.assertCountEqual(
+            [x.code for x in serializer.errors['non_field_errors']],
+            ['invalid'],
+        )
+
+    def test_input_invalid_unshared_post_option(self):
+        """PostCreateSerializerの入力データのバリデーション(NG: 投稿と選択肢でshare_idが共通でない)"""
+
+        share_id = uuid.uuid4()
+        data1 = {
+            'select_num': 0,
+            'answer': 'テスト1',
+            'votes': 1,
+            'share_id': share_id
+        }
+        data2 = {
+            'select_num': 1,
+            'answer': 'テスト2',
+            'votes': 2,
+            'share_id': share_id
+        }
+
+        # シリアライズ
+        input_data = {
+            'user': get_user_model().objects.get().id,
+            'question': 'テストだよ〜',
+            'options': [data1, data2],
+            'share_id': uuid.uuid4()
         }
         serializer = PostCreateSerializer(data=input_data)
         # バリデーションの結果を検証


### PR DESCRIPTION
## 投稿作成時のシリアライザのテストの実装
### テストの追加
- (正常)投稿作成機能のシリアライザ動作
- (異常)投稿作成機能において選択肢間で`share_id`を共有していない
- (異常)投稿作成機能において投稿と選択肢で`share_id`を共有していない
- (異常)質問文が１５０字以上
- (異常)選択肢が2個未満の時
- (異常)入力されていないデータが存在する
- (異常)blankな値が存在する

### テストのリファクタリング
- 必須な入力データが存在しない時に用いる関数をclass内でグローバルに定義

### バリデーションの追加
- シリアライザの`share_id`に関してバリデーションを作成
- 選択肢が2個未満の時のバリデーションを作成

## Issue
Closes #250 