### PR TITLE
[mod] メールアドレス確認後にログイン画面へ遷移できるように変更

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -12,6 +12,6 @@ urlpatterns = [
     path('api/v1/', include('apiv1.urls')),
     re_path(r'^mypage/.*', TemplateView.as_view(template_name='index.html'), name='index'),
     re_path(r'^settings/.*', TemplateView.as_view(template_name='index.html'), name='index'),
-    re_path(r'^login/.*', TemplateView.as_view(template_name='index.html'), name='index'),
+    re_path(r'^login/.*', TemplateView.as_view(template_name='index.html'), name='login'),
     re_path(r'^home/.*', TemplateView.as_view(template_name='index.html'), name='index')
 ]

--- a/templates/account/custom_email_confirmed.html
+++ b/templates/account/custom_email_confirmed.html
@@ -10,6 +10,6 @@
     <p class="Signup__email-confirm">
         {{username}}様のメールアドレスは確認されました。
     </p>
-    <p>登録したIDとパスワードにて<a href="{% url 'index' %}">コチラでログイン</a>をお願いいたします。</p>
+    <p>登録したIDとパスワードにて<a href="{% url 'login' %}">コチラでログイン</a>をお願いいたします。</p>
 </div>
 {% endblock %}


### PR DESCRIPTION
## メールアドレス確認後にログイン画面へ遷移できるように修正
- メールアドレス確認後にリンクを作成する
- urls.pyにて、loginのnameを定義する
- ローカルにて遷移できることを確認する

## Issue
Fixed #274 