### PR TITLE
[add] 管理者画面のユーザ一覧に登録日を追加

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -7,7 +7,7 @@ from .models import CustomUser
 class CustomUserAdmin(UserAdmin):
     """管理画面の表示する項目を設定"""
 
-    list_display = ('id', 'usernonamae', 'username', 'email', 'age', 'sex', 'blood_type', 'is_staff')
+    list_display = ('id', 'usernonamae', 'username', 'email', 'age', 'sex', 'blood_type', 'date_joined')
 
     fieldsets = (
         (None, {'fields': ('username', 'password')}),


### PR DESCRIPTION
## ユーザーを新しく登録して頂けても、誰が増えたのかわからない #305 
- admin.pyにて登録日のカラムを作成
- 管理者か否かのカラムを消去

## Issue
Closes #305 