### PR TITLE
SHA-27 CI/CD パイプライン（GitHub Actions）

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,48 @@
+name: Frontend CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Shappar/frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+  pull_request:
+    paths:
+      - 'Shappar/frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+
+jobs:
+  frontend-ci:
+    name: Lint, test, and build frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: Shappar/frontend
+    env:
+      CI: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: Shappar/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run Vitest with coverage
+        run: npm run test -- --coverage
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
## 概要

Shappar frontend 向けの GitHub Actions CI を追加し、frontend 変更時に lint / test / build を自動化します。

## 変更点

- `.github/workflows/frontend-ci.yml` を追加
- `Shappar/frontend` を working-directory に設定して `npm ci`, `npm run lint`, `npm run test -- --coverage`, `npm run build` を実行
- `actions/setup-node` の npm cache を有効化
- `push` to `main` と `pull_request` を frontend path 中心でトリガー
- workflow 変更自体も自己検証できるよう `.github/workflows/frontend-ci.yml` を trigger 対象に含めた

## 背景 / 目的

- Symphony エージェント生成コードの品質ゲートを自動化するため
- PR 単位で frontend の lint / test / build 成功を保証するため

## 影響範囲

- 対象画面: なし
- 対象ユーザー: 開発者 / レビュアー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before:
- After:

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [x] UI変更なし

## 確認項目

- [ ] ローカルで対象画面を確認（UI変更なしのため未実施）
- [ ] 主要導線を一通り操作（UI変更なしのため未実施）
- [x] `Shappar/frontend` で `npm run build` を実行
- [x] `Shappar/frontend` で `npm run lint` を実行
- [x] `Shappar/frontend` で `npm run test -- --coverage` を実行

## 関連issue

- SHA-27
- https://linear.app/shappar/issue/SHA-27/cicd-パイプラインgithub-actions

## 補足

- reviewer向け確認手順: workflow file の trigger, working-directory, Node setup, cache, lint/test/build step を確認してください。
- 必要な環境変数やログイン方法: なし
