### PR TITLE
SHA-19: implement Zustand auth store

### DIFF
--- a/Shappar/frontend/package-lock.json
+++ b/Shappar/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "firebase": "^12.11.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -7964,6 +7965,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/Shappar/frontend/package.json
+++ b/Shappar/frontend/package.json
@@ -22,7 +22,8 @@
     "firebase": "^12.11.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/Shappar/frontend/src/App.test.tsx
+++ b/Shappar/frontend/src/App.test.tsx
@@ -1,8 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authStoreMocks = vi.hoisted(() => {
+  const unsubscribe = vi.fn();
+  const initAuthListener = vi.fn(() => unsubscribe);
+
+  return { initAuthListener, unsubscribe };
+});
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: (selector: (state: { initAuthListener: () => () => void }) => unknown) =>
+    selector({ initAuthListener: authStoreMocks.initAuthListener }),
+}));
+
 import App from '@/App';
 import { render, screen, userEvent } from '@/test/test-utils';
 
 describe('App', () => {
+  beforeEach(() => {
+    authStoreMocks.unsubscribe.mockReset();
+    authStoreMocks.initAuthListener.mockReset();
+    authStoreMocks.initAuthListener.mockReturnValue(authStoreMocks.unsubscribe);
+  });
+
   it('renders the home page and supports a basic user interaction', async () => {
     const user = userEvent.setup();
 
@@ -23,5 +42,15 @@ describe('App', () => {
     await user.click(primaryButton);
 
     expect(primaryButton).toHaveFocus();
+  });
+
+  it('starts the auth listener on mount and cleans it up on unmount', () => {
+    const { unmount } = render(<App />);
+
+    expect(authStoreMocks.initAuthListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(authStoreMocks.unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/Shappar/frontend/src/App.tsx
+++ b/Shappar/frontend/src/App.tsx
@@ -1,6 +1,14 @@
+import { useEffect } from 'react';
 import { HomePage } from '@/pages/HomePage';
+import { useAuthStore } from '@/stores/auth-store';
 
 function App() {
+  const initAuthListener = useAuthStore((state) => state.initAuthListener);
+
+  useEffect(() => {
+    return initAuthListener();
+  }, [initAuthListener]);
+
   return <HomePage />;
 }
 

--- a/Shappar/frontend/src/stores/__tests__/auth-store.test.ts
+++ b/Shappar/frontend/src/stores/__tests__/auth-store.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { User as FirebaseUser } from 'firebase/auth';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return { auth: mockAuth };
+});
+
+async function loadAuthStore() {
+  return import('@/stores/auth-store');
+}
+
+function createMockUser(overrides: Partial<FirebaseUser> = {}): FirebaseUser {
+  return {
+    uid: 'user-123',
+    email: 'test@example.com',
+    displayName: 'Test User',
+    emailVerified: true,
+    isAnonymous: false,
+    metadata: {} as FirebaseUser['metadata'],
+    providerData: [],
+    refreshToken: 'refresh-token',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn(),
+    getIdTokenResult: vi.fn(),
+    reload: vi.fn(),
+    toJSON: vi.fn(),
+    phoneNumber: null,
+    photoURL: null,
+    providerId: 'firebase',
+    ...overrides,
+  } as FirebaseUser;
+}
+
+describe('auth store', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    const { resetFirebaseAuthMocks } = await import('@/test/mocks/firebase');
+    resetFirebaseAuthMocks();
+  });
+
+  it('starts with an unauthenticated loading state', async () => {
+    const { useAuthStore } = await loadAuthStore();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      firebaseUser: null,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+  });
+
+  it('sets a user and marks the session as authenticated', async () => {
+    const { useAuthStore } = await loadAuthStore();
+    const user = createMockUser();
+
+    useAuthStore.getState().setUser(user);
+
+    expect(useAuthStore.getState()).toMatchObject({
+      firebaseUser: user,
+      isAuthenticated: true,
+      isLoading: true,
+    });
+  });
+
+  it('clears the user and marks the session as unauthenticated', async () => {
+    const { useAuthStore } = await loadAuthStore();
+    const user = createMockUser();
+
+    useAuthStore.getState().setUser(user);
+    useAuthStore.getState().clearUser();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      firebaseUser: null,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+  });
+
+  it('updates the loading flag', async () => {
+    const { useAuthStore } = await loadAuthStore();
+
+    useAuthStore.getState().setLoading(false);
+
+    expect(useAuthStore.getState().isLoading).toBe(false);
+  });
+
+  it('registers the Firebase auth listener and returns its unsubscribe handle', async () => {
+    const { useAuthStore } = await loadAuthStore();
+    const { onAuthStateChanged } = await import('firebase/auth');
+    const { auth } = await import('@/lib/firebase');
+    const unsubscribe = vi.fn();
+
+    vi.mocked(onAuthStateChanged).mockImplementationOnce((_auth, callback) => {
+      (callback as (user: FirebaseUser | null) => void)(null);
+      return unsubscribe;
+    });
+
+    const result = useAuthStore.getState().initAuthListener();
+
+    expect(onAuthStateChanged).toHaveBeenCalledTimes(1);
+    expect(onAuthStateChanged).toHaveBeenCalledWith(
+      auth,
+      expect.any(Function),
+    );
+    expect(result).toBe(unsubscribe);
+  });
+
+  it('stores the Firebase user when the auth listener reports a login', async () => {
+    const { useAuthStore } = await loadAuthStore();
+    const { auth } = await import('@/lib/firebase');
+    const user = createMockUser({
+      uid: 'firebase-user',
+      email: 'firebase@example.com',
+      displayName: 'Firebase User',
+    });
+
+    (auth as { currentUser: FirebaseUser | null }).currentUser = user;
+
+    useAuthStore.getState().initAuthListener();
+
+    expect(useAuthStore.getState()).toMatchObject({
+      firebaseUser: user,
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    expect(useAuthStore.getState().firebaseUser?.uid).toBe('firebase-user');
+    expect(useAuthStore.getState().firebaseUser?.email).toBe(
+      'firebase@example.com',
+    );
+    expect(useAuthStore.getState().firebaseUser?.displayName).toBe(
+      'Firebase User',
+    );
+  });
+});

--- a/Shappar/frontend/src/stores/auth-store.ts
+++ b/Shappar/frontend/src/stores/auth-store.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { onAuthStateChanged, type User as FirebaseUser } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
+
+export interface AuthState {
+  firebaseUser: FirebaseUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  setUser: (user: FirebaseUser | null) => void;
+  clearUser: () => void;
+  setLoading: (loading: boolean) => void;
+  initAuthListener: () => () => void;
+}
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  firebaseUser: null,
+  isAuthenticated: false,
+  isLoading: true,
+  setUser: (user) =>
+    set({
+      firebaseUser: user,
+      isAuthenticated: Boolean(user),
+    }),
+  clearUser: () =>
+    set({
+      firebaseUser: null,
+      isAuthenticated: false,
+    }),
+  setLoading: (loading) => set({ isLoading: loading }),
+  initAuthListener: () =>
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        get().setUser(user);
+      } else {
+        get().clearUser();
+      }
+
+      get().setLoading(false);
+    }),
+}));


### PR DESCRIPTION
## 概要

Zustand ベースの認証ストアを追加し、アプリ起動時に Firebase auth listener を初期化できるようにしました。

## 変更点

- zustand を frontend に追加
- auth store を追加し、firebaseUser / isAuthenticated / isLoading と各 action を実装
- auth-store テストを追加し、初期状態・action・listener 連携を検証
- App で initAuthListener を useEffect から呼び出し、mount / unmount テストを追加

## 背景 / 目的

Firebase の onAuthStateChanged と連携したクライアント側認証状態を、アプリ全体で参照できる単一の store に集約するためです。

## 影響範囲

- 対象画面: アプリ起動時の認証初期化
- 対象ユーザー: フロントエンド利用者全体
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before:
- After:

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [x] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] react-front に変更がある場合は build 実行

## 関連issue

SHA-19

## 補足

- reviewer向け確認手順:
  - cd Shappar/frontend
  - npm run test:run
  - npm run build
  - auth-store と App の listener 初期化を確認
- 必要な環境変数やログイン方法:
  - Firebase env は既存の .env 設定を利用
