### PR TITLE
SHA-21 認証 API 連携（idToken → ユーザー情報取得）

### DIFF
--- a/Shappar/frontend/package-lock.json
+++ b/Shappar/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
+        "@tanstack/react-query": "^5.96.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "firebase": "^12.11.0",
@@ -1960,6 +1961,32 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.1.tgz",
+      "integrity": "sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.1.tgz",
+      "integrity": "sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/Shappar/frontend/package.json
+++ b/Shappar/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-query": "^5.96.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "firebase": "^12.11.0",

--- a/Shappar/frontend/src/App.tsx
+++ b/Shappar/frontend/src/App.tsx
@@ -1,5 +1,7 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { LoginPage } from '@/pages/login-page';
+import { queryClient } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
 
 function App() {
@@ -9,7 +11,11 @@ function App() {
     return initAuthListener();
   }, [initAuthListener]);
 
-  return <LoginPage />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <LoginPage />
+    </QueryClientProvider>
+  );
 }
 
 export default App;

--- a/Shappar/frontend/src/features/auth/__tests__/use-auth-mutation.test.ts
+++ b/Shappar/frontend/src/features/auth/__tests__/use-auth-mutation.test.ts
@@ -1,0 +1,192 @@
+import { act } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
+import { HttpResponse, http } from 'msw';
+import { createElement } from 'react';
+import type { PropsWithChildren } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return { auth: mockAuth };
+});
+
+import { useAuthMutation } from '@/features/auth/use-auth-mutation';
+import type { AuthUser } from '@/features/auth/types';
+import { createQueryClient } from '@/lib/query-client';
+import { useAuthStore } from '@/stores/auth-store';
+import { server } from '@/test/mocks/server';
+import { renderHook, waitFor } from '@/test/test-utils';
+
+const API_BASE_URL = 'http://localhost:8040';
+
+const mockAuthUser: AuthUser = {
+  unique_id: 'unique-user-123',
+  user_id: 'user-123',
+  name: 'Shappar User',
+  introduction: 'I love taking pictures with friends.',
+  iconimage: 'https://example.com/icon.png',
+  homeimage: 'https://example.com/home.png',
+};
+
+function createMockFirebaseUser(overrides: Partial<FirebaseUser> = {}) {
+  return {
+    uid: 'firebase-user-123',
+    email: 'firebase@example.com',
+    displayName: 'Firebase User',
+    ...overrides,
+  } as FirebaseUser;
+}
+
+function createWrapper() {
+  const queryClient = createQueryClient();
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+describe('useAuthMutation', () => {
+  beforeEach(() => {
+    vi.mocked(getIdToken).mockReset();
+
+    useAuthStore.setState({
+      firebaseUser: null,
+      authUser: null,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth`, () => {
+        return HttpResponse.json({ user: mockAuthUser });
+      }),
+    );
+  });
+
+  it('sends the idToken and returns the authenticated user', async () => {
+    const firebaseUser = createMockFirebaseUser();
+    let authorizationHeader: string | null = null;
+
+    vi.mocked(getIdToken).mockResolvedValueOnce('valid-id-token');
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth`, ({ request }) => {
+        authorizationHeader = request.headers.get('authorization');
+
+        return HttpResponse.json({ user: mockAuthUser });
+      }),
+    );
+
+    const { result } = renderHook(() => useAuthMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    let response:
+      | {
+          user: AuthUser;
+        }
+      | undefined;
+
+    await act(async () => {
+      response = await result.current.mutateAsync(firebaseUser);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(getIdToken).toHaveBeenCalledTimes(1);
+    expect(getIdToken).toHaveBeenCalledWith(firebaseUser);
+    expect(authorizationHeader).toBe('Bearer valid-id-token');
+    expect(response).toEqual({ user: mockAuthUser });
+  });
+
+  it('stores the authenticated user in the auth store on success', async () => {
+    const firebaseUser = createMockFirebaseUser();
+
+    vi.mocked(getIdToken).mockResolvedValueOnce('valid-id-token');
+
+    const { result } = renderHook(() => useAuthMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(firebaseUser);
+    });
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().authUser).toEqual(mockAuthUser);
+    });
+  });
+
+  it('surfaces an unauthorized error when the idToken is invalid', async () => {
+    const firebaseUser = createMockFirebaseUser();
+    let mutationError: unknown;
+
+    vi.mocked(getIdToken).mockResolvedValueOnce('invalid-id-token');
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth`, () => {
+        return HttpResponse.json(
+          { message: 'Unauthorized' },
+          { status: 401 },
+        );
+      }),
+    );
+
+    const { result } = renderHook(() => useAuthMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(firebaseUser);
+      } catch (error) {
+        mutationError = error;
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mutationError).toMatchObject({ status: 401 });
+    expect(useAuthStore.getState().authUser).toBeNull();
+  });
+
+  it('surfaces a network error when the request cannot be completed', async () => {
+    const firebaseUser = createMockFirebaseUser();
+    let mutationError: unknown;
+
+    vi.mocked(getIdToken).mockResolvedValueOnce('valid-id-token');
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth`, () => {
+        return HttpResponse.error();
+      }),
+    );
+
+    const { result } = renderHook(() => useAuthMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(firebaseUser);
+      } catch (error) {
+        mutationError = error;
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mutationError).toBeInstanceOf(Error);
+    expect(useAuthStore.getState().authUser).toBeNull();
+  });
+});

--- a/Shappar/frontend/src/features/auth/__tests__/use-auth-mutation.test.ts
+++ b/Shappar/frontend/src/features/auth/__tests__/use-auth-mutation.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/firebase', async () => {
 });
 
 import { useAuthMutation } from '@/features/auth/use-auth-mutation';
-import type { AuthUser } from '@/features/auth/types';
+import type { AuthResponse, AuthUser } from '@/features/auth/types';
 import { createQueryClient } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
 import { server } from '@/test/mocks/server';
@@ -65,7 +65,7 @@ describe('useAuthMutation', () => {
 
     server.use(
       http.post(`${API_BASE_URL}/api/v1/auth`, () => {
-        return HttpResponse.json({ user: mockAuthUser });
+        return HttpResponse.json(mockAuthUser);
       }),
     );
   });
@@ -79,7 +79,7 @@ describe('useAuthMutation', () => {
       http.post(`${API_BASE_URL}/api/v1/auth`, ({ request }) => {
         authorizationHeader = request.headers.get('authorization');
 
-        return HttpResponse.json({ user: mockAuthUser });
+        return HttpResponse.json(mockAuthUser);
       }),
     );
 
@@ -88,9 +88,7 @@ describe('useAuthMutation', () => {
     });
 
     let response:
-      | {
-          user: AuthUser;
-        }
+      | AuthUser
       | undefined;
 
     await act(async () => {
@@ -104,7 +102,7 @@ describe('useAuthMutation', () => {
     expect(getIdToken).toHaveBeenCalledTimes(1);
     expect(getIdToken).toHaveBeenCalledWith(firebaseUser);
     expect(authorizationHeader).toBe('Bearer valid-id-token');
-    expect(response).toEqual({ user: mockAuthUser });
+    expect(response).toEqual(mockAuthUser);
   });
 
   it('stores the authenticated user in the auth store on success', async () => {
@@ -123,6 +121,37 @@ describe('useAuthMutation', () => {
     await waitFor(() => {
       expect(useAuthStore.getState().authUser).toEqual(mockAuthUser);
     });
+  });
+
+  it('accepts a nested user payload from the auth API', async () => {
+    const firebaseUser = createMockFirebaseUser();
+
+    vi.mocked(getIdToken).mockResolvedValueOnce('valid-id-token');
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/auth`, () => {
+        return HttpResponse.json({
+          user: mockAuthUser,
+        } satisfies AuthResponse);
+      }),
+    );
+
+    const { result } = renderHook(() => useAuthMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    let response:
+      | AuthUser
+      | undefined;
+
+    await act(async () => {
+      response = await result.current.mutateAsync(firebaseUser);
+    });
+
+    await waitFor(() => {
+      expect(useAuthStore.getState().authUser).toEqual(mockAuthUser);
+    });
+
+    expect(response).toEqual(mockAuthUser);
   });
 
   it('surfaces an unauthorized error when the idToken is invalid', async () => {

--- a/Shappar/frontend/src/features/auth/types.ts
+++ b/Shappar/frontend/src/features/auth/types.ts
@@ -1,0 +1,12 @@
+export interface AuthUser {
+  unique_id: string;
+  user_id: string;
+  name: string;
+  introduction: string;
+  iconimage: string;
+  homeimage: string;
+}
+
+export interface AuthResponse {
+  user: AuthUser;
+}

--- a/Shappar/frontend/src/features/auth/types.ts
+++ b/Shappar/frontend/src/features/auth/types.ts
@@ -7,6 +7,16 @@ export interface AuthUser {
   homeimage: string;
 }
 
-export interface AuthResponse {
+export interface NestedAuthResponse {
   user: AuthUser;
+}
+
+export type AuthResponse = AuthUser | NestedAuthResponse;
+
+export function extractAuthUser(response: AuthResponse): AuthUser {
+  if ('user' in response) {
+    return response.user;
+  }
+
+  return response;
 }

--- a/Shappar/frontend/src/features/auth/use-auth-mutation.ts
+++ b/Shappar/frontend/src/features/auth/use-auth-mutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
-import type { AuthResponse } from '@/features/auth/types';
+import { extractAuthUser, type AuthResponse } from '@/features/auth/types';
 import { apiClient } from '@/lib/api-client';
 import { useAuthStore } from '@/stores/auth-store';
 
@@ -14,14 +14,15 @@ export function useAuthMutation() {
     },
     mutationFn: async (firebaseUser: FirebaseUser) => {
       const idToken = await getIdToken(firebaseUser);
-
-      return apiClient<AuthResponse>('/api/v1/auth', {
+      const response = await apiClient<AuthResponse>('/api/v1/auth', {
         method: 'POST',
         idToken,
       });
+
+      return extractAuthUser(response);
     },
-    onSuccess: (response) => {
-      setAuthUser(response.user);
+    onSuccess: (authUser) => {
+      setAuthUser(authUser);
     },
   });
 }

--- a/Shappar/frontend/src/features/auth/use-auth-mutation.ts
+++ b/Shappar/frontend/src/features/auth/use-auth-mutation.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
+import type { AuthResponse } from '@/features/auth/types';
+import { apiClient } from '@/lib/api-client';
+import { useAuthStore } from '@/stores/auth-store';
+
+export function useAuthMutation() {
+  const setAuthUser = useAuthStore((state) => state.setAuthUser);
+  const clearAuthUser = useAuthStore((state) => state.clearAuthUser);
+
+  return useMutation({
+    onMutate: () => {
+      clearAuthUser();
+    },
+    mutationFn: async (firebaseUser: FirebaseUser) => {
+      const idToken = await getIdToken(firebaseUser);
+
+      return apiClient<AuthResponse>('/api/v1/auth', {
+        method: 'POST',
+        idToken,
+      });
+    },
+    onSuccess: (response) => {
+      setAuthUser(response.user);
+    },
+  });
+}

--- a/Shappar/frontend/src/lib/api-client.ts
+++ b/Shappar/frontend/src/lib/api-client.ts
@@ -1,0 +1,95 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:8040';
+
+type ApiClientOptions = RequestInit & {
+  idToken?: string;
+};
+
+type ErrorResponseBody = {
+  message?: string;
+};
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function getApiBaseUrl() {
+  return import.meta.env.VITE_API_BASE_URL ?? DEFAULT_API_BASE_URL;
+}
+
+function buildHeaders({ body, headers, idToken }: ApiClientOptions) {
+  const requestHeaders = new Headers(headers);
+
+  if (
+    body &&
+    !(body instanceof FormData) &&
+    !requestHeaders.has('Content-Type')
+  ) {
+    requestHeaders.set('Content-Type', 'application/json');
+  }
+
+  if (idToken) {
+    requestHeaders.set('Authorization', `Bearer ${idToken}`);
+  }
+
+  return requestHeaders;
+}
+
+async function parseResponseBody(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    const json: unknown = await response.json();
+
+    return json;
+  }
+
+  const text = await response.text();
+
+  return text.length > 0 ? text : null;
+}
+
+function getErrorMessage(status: number, body: unknown) {
+  if (
+    body &&
+    typeof body === 'object' &&
+    'message' in body &&
+    typeof (body as ErrorResponseBody).message === 'string'
+  ) {
+    return (body as ErrorResponseBody).message!;
+  }
+
+  return `Request failed with status ${status}`;
+}
+
+export async function apiClient<T>(
+  path: string,
+  options: ApiClientOptions = {},
+) {
+  const response = await fetch(new URL(path, getApiBaseUrl()).toString(), {
+    ...options,
+    headers: buildHeaders(options),
+  });
+  const body = await parseResponseBody(response);
+
+  if (!response.ok) {
+    throw new ApiError(
+      getErrorMessage(response.status, body),
+      response.status,
+      body,
+    );
+  }
+
+  return body as T;
+}

--- a/Shappar/frontend/src/lib/query-client.ts
+++ b/Shappar/frontend/src/lib/query-client.ts
@@ -1,0 +1,16 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export const queryClient = createQueryClient();

--- a/Shappar/frontend/src/mocks/handlers.ts
+++ b/Shappar/frontend/src/mocks/handlers.ts
@@ -1,6 +1,24 @@
 import { HttpResponse, http } from 'msw';
 
+const mockAuthUser = {
+  unique_id: 'unique-user-123',
+  user_id: 'user-123',
+  name: 'Shappar User',
+  introduction: 'I love taking pictures with friends.',
+  iconimage: 'https://example.com/icon.png',
+  homeimage: 'https://example.com/home.png',
+};
+
 export const handlers = [
+  http.post('http://localhost:8040/api/v1/auth', ({ request }) => {
+    const authorization = request.headers.get('authorization');
+
+    if (!authorization || authorization === 'Bearer invalid-id-token') {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    return HttpResponse.json({ user: mockAuthUser });
+  }),
   http.get('/api/v1/health', () => {
     return HttpResponse.json({ status: 'ok' });
   }),

--- a/Shappar/frontend/src/mocks/handlers.ts
+++ b/Shappar/frontend/src/mocks/handlers.ts
@@ -17,7 +17,7 @@ export const handlers = [
       return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
 
-    return HttpResponse.json({ user: mockAuthUser });
+    return HttpResponse.json(mockAuthUser);
   }),
   http.get('/api/v1/health', () => {
     return HttpResponse.json({ status: 'ok' });

--- a/Shappar/frontend/src/pages/__tests__/login-page.test.tsx
+++ b/Shappar/frontend/src/pages/__tests__/login-page.test.tsx
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { signInWithPopup } from 'firebase/auth';
 
+const authMutationMocks = vi.hoisted(() => ({
+  isPending: false,
+  mutateAsync: vi.fn(),
+}));
+
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
 vi.mock('@/lib/firebase', async () => {
   const { GoogleAuthProvider, mockAuth } = await import('@/test/mocks/firebase');
@@ -10,6 +15,12 @@ vi.mock('@/lib/firebase', async () => {
     googleProvider: new GoogleAuthProvider(),
   };
 });
+vi.mock('@/features/auth/use-auth-mutation', () => ({
+  useAuthMutation: () => ({
+    isPending: authMutationMocks.isPending,
+    mutateAsync: authMutationMocks.mutateAsync,
+  }),
+}));
 
 import { auth, googleProvider } from '@/lib/firebase';
 import { LoginPage } from '@/pages/login-page';
@@ -35,6 +46,8 @@ describe('LoginPage', () => {
   beforeEach(async () => {
     const { resetFirebaseAuthMocks } = await import('@/test/mocks/firebase');
     resetFirebaseAuthMocks();
+    authMutationMocks.isPending = false;
+    authMutationMocks.mutateAsync.mockReset();
   });
 
   it('renders the login page', () => {
@@ -63,8 +76,14 @@ describe('LoginPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('calls signInWithPopup when the Google login button is clicked', async () => {
+  it('calls signInWithPopup and authenticates the user when login succeeds', async () => {
     const user = userEvent.setup();
+    const firebaseUser = { uid: 'firebase-user-123' };
+
+    authMutationMocks.mutateAsync.mockResolvedValueOnce(undefined);
+    vi.mocked(signInWithPopup).mockResolvedValueOnce({
+      user: firebaseUser,
+    } as never);
 
     render(<LoginPage />);
 
@@ -76,6 +95,9 @@ describe('LoginPage', () => {
 
     expect(signInWithPopup).toHaveBeenCalledTimes(1);
     expect(signInWithPopup).toHaveBeenCalledWith(auth, googleProvider);
+    await waitFor(() => {
+      expect(authMutationMocks.mutateAsync).toHaveBeenCalledWith(firebaseUser);
+    });
   });
 
   it('shows a loading state while login is in progress', async () => {
@@ -105,6 +127,19 @@ describe('LoginPage', () => {
     });
   });
 
+  it('shows the auth API loading state while user information is being fetched', () => {
+    authMutationMocks.isPending = true;
+
+    render(<LoginPage />);
+
+    expect(
+      screen.getByRole('button', {
+        name: '認証情報を確認中...',
+      }),
+    ).toBeDisabled();
+    expect(screen.getByTestId('google-login-spinner')).toBeInTheDocument();
+  });
+
   it('shows an error message when login fails', async () => {
     const user = userEvent.setup();
 
@@ -123,6 +158,32 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent(
         'Google ログインに失敗しました。時間をおいて再度お試しください。',
+      );
+    });
+  });
+
+  it('shows an auth API error message when server authentication fails', async () => {
+    const user = userEvent.setup();
+    const firebaseUser = { uid: 'firebase-user-123' };
+
+    authMutationMocks.mutateAsync.mockRejectedValueOnce(
+      new TypeError('fetch failed'),
+    );
+    vi.mocked(signInWithPopup).mockResolvedValueOnce({
+      user: firebaseUser,
+    } as never);
+
+    render(<LoginPage />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Google でログイン',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'ログイン後の認証に失敗しました。時間をおいて再度お試しください。',
       );
     });
   });

--- a/Shappar/frontend/src/pages/login-page.tsx
+++ b/Shappar/frontend/src/pages/login-page.tsx
@@ -8,10 +8,16 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { useAuthMutation } from '@/features/auth/use-auth-mutation';
+import { ApiError } from '@/lib/api-client';
 import { auth, googleProvider } from '@/lib/firebase';
 
-const DEFAULT_ERROR_MESSAGE =
+const DEFAULT_LOGIN_ERROR_MESSAGE =
   'Google ログインに失敗しました。時間をおいて再度お試しください。';
+const DEFAULT_AUTH_ERROR_MESSAGE =
+  'ログイン後の認証に失敗しました。時間をおいて再度お試しください。';
+const UNAUTHORIZED_AUTH_ERROR_MESSAGE =
+  'ログイン後の認証に失敗しました。もう一度お試しください。';
 
 function shouldIgnoreAuthError(error: unknown) {
   if (!error || typeof error !== 'object' || !('code' in error)) {
@@ -21,22 +27,41 @@ function shouldIgnoreAuthError(error: unknown) {
   return String(error.code).endsWith('popup-closed-by-user');
 }
 
+function getAuthErrorMessage(error: unknown) {
+  if (error instanceof ApiError && error.status === 401) {
+    return UNAUTHORIZED_AUTH_ERROR_MESSAGE;
+  }
+
+  return DEFAULT_AUTH_ERROR_MESSAGE;
+}
+
 export function LoginPage() {
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { mutateAsync: authenticateUser, isPending: isAuthenticating } =
+    useAuthMutation();
+  const isLoading = isLoggingIn || isAuthenticating;
 
   const handleGoogleLogin = async () => {
-    setIsLoading(true);
+    setIsLoggingIn(true);
     setError(null);
 
     try {
-      await signInWithPopup(auth, googleProvider);
+      const credentials = await signInWithPopup(auth, googleProvider);
+
+      setIsLoggingIn(false);
+
+      await authenticateUser(credentials.user);
     } catch (loginError) {
       if (!shouldIgnoreAuthError(loginError)) {
-        setError(DEFAULT_ERROR_MESSAGE);
+        setError(
+          loginError instanceof ApiError || loginError instanceof TypeError
+            ? getAuthErrorMessage(loginError)
+            : DEFAULT_LOGIN_ERROR_MESSAGE,
+        );
       }
     } finally {
-      setIsLoading(false);
+      setIsLoggingIn(false);
     }
   };
 
@@ -87,7 +112,11 @@ export function LoginPage() {
                       fill="currentColor"
                     />
                   </svg>
-                  <span>ログイン中...</span>
+                  <span>
+                    {isAuthenticating
+                      ? '認証情報を確認中...'
+                      : 'ログイン中...'}
+                  </span>
                 </>
               ) : (
                 'Google でログイン'

--- a/Shappar/frontend/src/stores/__tests__/auth-store.test.ts
+++ b/Shappar/frontend/src/stores/__tests__/auth-store.test.ts
@@ -47,6 +47,7 @@ describe('auth store', () => {
 
     expect(useAuthStore.getState()).toMatchObject({
       firebaseUser: null,
+      authUser: null,
       isAuthenticated: false,
       isLoading: true,
     });
@@ -60,6 +61,7 @@ describe('auth store', () => {
 
     expect(useAuthStore.getState()).toMatchObject({
       firebaseUser: user,
+      authUser: null,
       isAuthenticated: true,
       isLoading: true,
     });
@@ -74,9 +76,30 @@ describe('auth store', () => {
 
     expect(useAuthStore.getState()).toMatchObject({
       firebaseUser: null,
+      authUser: null,
       isAuthenticated: false,
       isLoading: true,
     });
+  });
+
+  it('stores and clears the authenticated API user separately from Firebase auth', async () => {
+    const { useAuthStore } = await loadAuthStore();
+    const authUser = {
+      unique_id: 'unique-123',
+      user_id: 'user-123',
+      name: 'Auth User',
+      introduction: 'Hello',
+      iconimage: 'https://example.com/icon.png',
+      homeimage: 'https://example.com/home.png',
+    };
+
+    useAuthStore.getState().setAuthUser(authUser);
+
+    expect(useAuthStore.getState().authUser).toEqual(authUser);
+
+    useAuthStore.getState().clearAuthUser();
+
+    expect(useAuthStore.getState().authUser).toBeNull();
   });
 
   it('updates the loading flag', async () => {
@@ -123,6 +146,7 @@ describe('auth store', () => {
 
     expect(useAuthStore.getState()).toMatchObject({
       firebaseUser: user,
+      authUser: null,
       isAuthenticated: true,
       isLoading: false,
     });

--- a/Shappar/frontend/src/stores/auth-store.ts
+++ b/Shappar/frontend/src/stores/auth-store.ts
@@ -1,19 +1,24 @@
 import { create } from 'zustand';
 import { onAuthStateChanged, type User as FirebaseUser } from 'firebase/auth';
+import type { AuthUser } from '@/features/auth/types';
 import { auth } from '@/lib/firebase';
 
 export interface AuthState {
   firebaseUser: FirebaseUser | null;
+  authUser: AuthUser | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   setUser: (user: FirebaseUser | null) => void;
   clearUser: () => void;
+  setAuthUser: (user: AuthUser | null) => void;
+  clearAuthUser: () => void;
   setLoading: (loading: boolean) => void;
   initAuthListener: () => () => void;
 }
 
 export const useAuthStore = create<AuthState>((set, get) => ({
   firebaseUser: null,
+  authUser: null,
   isAuthenticated: false,
   isLoading: true,
   setUser: (user) =>
@@ -24,8 +29,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   clearUser: () =>
     set({
       firebaseUser: null,
+      authUser: null,
       isAuthenticated: false,
     }),
+  setAuthUser: (user) => set({ authUser: user }),
+  clearAuthUser: () => set({ authUser: null }),
   setLoading: (loading) => set({ isLoading: loading }),
   initAuthListener: () =>
     onAuthStateChanged(auth, (user) => {

--- a/Shappar/frontend/src/test/mocks/handlers.ts
+++ b/Shappar/frontend/src/test/mocks/handlers.ts
@@ -1,6 +1,24 @@
 import { HttpResponse, http } from 'msw';
 
+const mockAuthUser = {
+  unique_id: 'unique-user-123',
+  user_id: 'user-123',
+  name: 'Shappar User',
+  introduction: 'I love taking pictures with friends.',
+  iconimage: 'https://example.com/icon.png',
+  homeimage: 'https://example.com/home.png',
+};
+
 export const handlers = [
+  http.post('http://localhost:8040/api/v1/auth', ({ request }) => {
+    const authorization = request.headers.get('authorization');
+
+    if (!authorization || authorization === 'Bearer invalid-id-token') {
+      return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+
+    return HttpResponse.json({ user: mockAuthUser });
+  }),
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' });
   }),

--- a/Shappar/frontend/src/test/mocks/handlers.ts
+++ b/Shappar/frontend/src/test/mocks/handlers.ts
@@ -17,7 +17,7 @@ export const handlers = [
       return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
 
-    return HttpResponse.json({ user: mockAuthUser });
+    return HttpResponse.json(mockAuthUser);
   }),
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' });


### PR DESCRIPTION
## 概要

Firebase ログイン成功後に idToken を `/api/v1/auth` へ送信し、Go API のユーザー情報を Zustand に保持する認証連携を追加しました。

## 変更点

- `@tanstack/react-query` を追加し、`App` に `QueryClientProvider` を導入
- Bearer idToken 付き `apiClient`、auth 型定義、`useAuthMutation` を追加
- auth store に `authUser` を追加し、`LoginPage` でログイン直後に backend auth を実行
- MSW handler と hook / login / store テストを追加し、401 とネットワークエラーも検証

## 背景 / 目的

Firebase session だけでは app 固有のユーザー情報が不足するため、ログイン直後に Go server の auth endpoint と同期し、`unique_id` などを取得できるようにします。

## 影響範囲

- 対象画面: `Shappar/frontend` のログイン画面
- 対象ユーザー: Google ログインを行うユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: Google ログイン完了後は Firebase 認証のみで、backend user 取得と専用ローディング表示がなかった
- After: Google ログイン成功後に `POST /api/v1/auth` を実行し、`認証情報を確認中...` 表示と auth API エラー表示を追加

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [ ] ローカルで対象画面を確認
- [ ] 主要導線を一通り操作
- [x] `react-front` に変更がある場合は `build` 実行

## 関連issue

close https://linear.app/shappar/issue/SHA-21/認証-api-連携idtoken-ユーザー情報取得

## 補足

- reviewer向け確認手順:
  - `cd Shappar/frontend && npm run lint`
  - `cd Shappar/frontend && npm run test:run`
  - `cd Shappar/frontend && npm run build`
  - Google ログイン成功後に `認証情報を確認中...` 表示と auth API エラー表示を確認
- 必要な環境変数やログイン方法:
  - `VITE_FIREBASE_*`
  - `VITE_API_BASE_URL`（未指定時は `http://localhost:8040`）
