### PR TITLE
SHA-22 React Router ルーティング設計・認証ガード

### DIFF
--- a/Shappar/frontend/package-lock.json
+++ b/Shappar/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "firebase": "^12.11.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.13.2",
         "tailwind-merge": "^3.5.0",
         "zustand": "^5.0.12"
       },
@@ -3245,7 +3246,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6384,6 +6384,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "dev": true,
@@ -6692,6 +6730,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/Shappar/frontend/package.json
+++ b/Shappar/frontend/package.json
@@ -23,6 +23,7 @@
     "firebase": "^12.11.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-router-dom": "^7.13.2",
     "tailwind-merge": "^3.5.0",
     "zustand": "^5.0.12"
   },

--- a/Shappar/frontend/src/App.test.tsx
+++ b/Shappar/frontend/src/App.test.tsx
@@ -3,21 +3,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const authStoreMocks = vi.hoisted(() => {
   const unsubscribe = vi.fn();
   const initAuthListener = vi.fn(() => unsubscribe);
+  const routerProvider = vi.fn((_router: unknown) => (
+    <div data-testid="router-provider" />
+  ));
 
-  return { initAuthListener, unsubscribe };
+  return { initAuthListener, routerProvider, unsubscribe };
 });
 
 vi.mock('@/stores/auth-store', () => ({
   useAuthStore: (selector: (state: { initAuthListener: () => () => void }) => unknown) =>
     selector({ initAuthListener: authStoreMocks.initAuthListener }),
 }));
-vi.mock('@/pages/login-page', () => ({
-  LoginPage: () => (
-    <main>
-      <h1>Shappar</h1>
-      <button type="button">Google でログイン</button>
-    </main>
-  ),
+vi.mock('@/router', () => ({
+  router: { id: 'app-router' },
+}));
+vi.mock('react-router-dom', async () => ({
+  RouterProvider: ({
+    router,
+  }: {
+    router: unknown;
+  }) => authStoreMocks.routerProvider(router),
 }));
 
 import App from '@/App';
@@ -28,27 +33,25 @@ describe('App', () => {
     authStoreMocks.unsubscribe.mockReset();
     authStoreMocks.initAuthListener.mockReset();
     authStoreMocks.initAuthListener.mockReturnValue(authStoreMocks.unsubscribe);
+    authStoreMocks.routerProvider.mockClear();
+    authStoreMocks.routerProvider.mockReturnValue(
+      <div data-testid="router-provider" />,
+    );
   });
 
-  it('renders the login page', () => {
+  it('renders the app router', () => {
     render(<App />);
 
-    expect(
-      screen.getByRole('heading', {
-        name: 'Shappar',
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {
-        name: 'Google でログイン',
-      }),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('router-provider')).toBeInTheDocument();
   });
 
   it('starts the auth listener on mount and cleans it up on unmount', () => {
     const { unmount } = render(<App />);
 
     expect(authStoreMocks.initAuthListener).toHaveBeenCalledTimes(1);
+    expect(authStoreMocks.routerProvider).toHaveBeenCalledWith({
+      id: 'app-router',
+    });
 
     unmount();
 

--- a/Shappar/frontend/src/App.test.tsx
+++ b/Shappar/frontend/src/App.test.tsx
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const authStoreMocks = vi.hoisted(() => {
   const unsubscribe = vi.fn();
   const initAuthListener = vi.fn(() => unsubscribe);
-  const routerProvider = vi.fn((_router: unknown) => (
-    <div data-testid="router-provider" />
-  ));
+  const routerProvider = vi.fn((router: unknown) => {
+    void router;
+
+    return <div data-testid="router-provider" />;
+  });
 
   return { initAuthListener, routerProvider, unsubscribe };
 });
@@ -17,7 +19,7 @@ vi.mock('@/stores/auth-store', () => ({
 vi.mock('@/router', () => ({
   router: { id: 'app-router' },
 }));
-vi.mock('react-router-dom', async () => ({
+vi.mock('react-router-dom', () => ({
   RouterProvider: ({
     router,
   }: {

--- a/Shappar/frontend/src/App.tsx
+++ b/Shappar/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
-import { LoginPage } from '@/pages/login-page';
+import { RouterProvider } from 'react-router-dom';
+import { router } from '@/router';
 import { queryClient } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
 
@@ -13,7 +14,7 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <LoginPage />
+      <RouterProvider router={router} />
     </QueryClientProvider>
   );
 }

--- a/Shappar/frontend/src/__tests__/router.test.tsx
+++ b/Shappar/frontend/src/__tests__/router.test.tsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { appRoutes } from '@/router';
+import { render, screen } from '@/test/test-utils';
+
+const authStoreState = vi.hoisted(() => ({
+  initAuthListener: vi.fn(() => vi.fn()),
+  isAuthenticated: false,
+  isLoading: false,
+}));
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: (
+    selector: (
+      state: {
+        initAuthListener: () => () => void;
+        isAuthenticated: boolean;
+        isLoading: boolean;
+      },
+    ) => unknown,
+  ) => selector(authStoreState),
+}));
+
+vi.mock('@/pages/login-page', () => ({
+  LoginPage: () => <h1>Mock Login Page</h1>,
+}));
+
+vi.mock('@/pages/home-page', () => ({
+  HomePage: () => <h1>Mock Home Page</h1>,
+}));
+
+vi.mock('@/pages/not-found-page', () => ({
+  NotFoundPage: () => <h1>Mock Not Found Page</h1>,
+}));
+
+function renderRouter(pathname: string) {
+  const router = createMemoryRouter(appRoutes, {
+    initialEntries: [pathname],
+  });
+
+  return render(<RouterProvider router={router} />);
+}
+
+describe('app router', () => {
+  beforeEach(() => {
+    authStoreState.isAuthenticated = false;
+    authStoreState.isLoading = false;
+  });
+
+  it('routes unauthenticated users on /login to the public login page', () => {
+    renderRouter('/login');
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Mock Login Page',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('routes authenticated users on / to the protected home page', () => {
+    authStoreState.isAuthenticated = true;
+
+    renderRouter('/');
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Mock Home Page',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the not-found page for unknown paths', () => {
+    renderRouter('/missing');
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Mock Not Found Page',
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/Shappar/frontend/src/components/__tests__/auth-guard.test.tsx
+++ b/Shappar/frontend/src/components/__tests__/auth-guard.test.tsx
@@ -28,9 +28,16 @@ vi.mock('@/stores/auth-store', () => ({
 
 function LoginLocationProbe() {
   const location = useLocation();
-  const from = location.state?.from as
-    | { hash?: string; pathname?: string; search?: string }
-    | undefined;
+  const state = location.state as
+    | {
+        from?: {
+          hash?: string;
+          pathname?: string;
+          search?: string;
+        };
+      }
+    | null;
+  const from = state?.from;
 
   return (
     <main>

--- a/Shappar/frontend/src/components/__tests__/auth-guard.test.tsx
+++ b/Shappar/frontend/src/components/__tests__/auth-guard.test.tsx
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom';
+import { ProtectedRoute, PublicRoute } from '@/components/auth-guard';
+import { render, screen } from '@/test/test-utils';
+
+const authStoreState = vi.hoisted(() => ({
+  initAuthListener: vi.fn(() => vi.fn()),
+  isAuthenticated: false,
+  isLoading: false,
+}));
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: (
+    selector: (
+      state: {
+        initAuthListener: () => () => void;
+        isAuthenticated: boolean;
+        isLoading: boolean;
+      },
+    ) => unknown,
+  ) => selector(authStoreState),
+}));
+
+function LoginLocationProbe() {
+  const location = useLocation();
+  const from = location.state?.from as
+    | { hash?: string; pathname?: string; search?: string }
+    | undefined;
+
+  return (
+    <main>
+      <h1>Login Page</h1>
+      <p data-testid="current-path">{location.pathname}</p>
+      <p data-testid="from-pathname">{from?.pathname ?? 'none'}</p>
+      <p data-testid="from-search">{from?.search ?? 'none'}</p>
+      <p data-testid="from-hash">{from?.hash ?? 'none'}</p>
+    </main>
+  );
+}
+
+describe('auth guards', () => {
+  beforeEach(() => {
+    authStoreState.isAuthenticated = false;
+    authStoreState.isLoading = false;
+  });
+
+  it('redirects unauthenticated users from protected routes to /login', () => {
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/protected" element={<p>Protected Page</p>} />
+          </Route>
+          <Route path="/login" element={<LoginLocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Login Page',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/login');
+  });
+
+  it('renders protected content for authenticated users', () => {
+    authStoreState.isAuthenticated = true;
+
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/protected" element={<p>Protected Page</p>} />
+          </Route>
+          <Route path="/login" element={<LoginLocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Protected Page')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Login Page',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('redirects authenticated users away from /login', () => {
+    authStoreState.isAuthenticated = true;
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route element={<PublicRoute />}>
+            <Route path="/login" element={<p>Login Page</p>} />
+          </Route>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/" element={<p>Home Page</p>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Home Page')).toBeInTheDocument();
+    expect(screen.queryByText('Login Page')).not.toBeInTheDocument();
+  });
+
+  it('shows a loading state while authentication is initializing', () => {
+    authStoreState.isLoading = true;
+
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/protected" element={<p>Protected Page</p>} />
+          </Route>
+          <Route path="/login" element={<LoginLocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '認証状態を確認しています...',
+    );
+    expect(screen.queryByText('Protected Page')).not.toBeInTheDocument();
+  });
+
+  it('preserves the original location in redirect state for post-login return', () => {
+    render(
+      <MemoryRouter initialEntries={['/polls/42?filter=open#recent']}>
+        <Routes>
+          <Route element={<ProtectedRoute />}>
+            <Route path="/polls/:pollId" element={<p>Poll Detail</p>} />
+          </Route>
+          <Route path="/login" element={<LoginLocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/login');
+    expect(screen.getByTestId('from-pathname')).toHaveTextContent('/polls/42');
+    expect(screen.getByTestId('from-search')).toHaveTextContent(
+      '?filter=open',
+    );
+    expect(screen.getByTestId('from-hash')).toHaveTextContent('#recent');
+  });
+});

--- a/Shappar/frontend/src/components/auth-guard.tsx
+++ b/Shappar/frontend/src/components/auth-guard.tsx
@@ -1,0 +1,83 @@
+import {
+  Navigate,
+  Outlet,
+  useLocation,
+  type Location,
+} from 'react-router-dom';
+import { useAuthStore } from '@/stores/auth-store';
+
+type RedirectState = {
+  from: Location;
+};
+
+function AuthLoadingScreen() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div
+        aria-live="polite"
+        className="flex flex-col items-center gap-4 text-center text-slate-700"
+        role="status"
+      >
+        <svg
+          aria-hidden="true"
+          className="size-8 animate-spin text-sky-600"
+          data-testid="auth-guard-spinner"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+            fill="none"
+          />
+          <path
+            className="opacity-90"
+            d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4Z"
+            fill="currentColor"
+          />
+        </svg>
+        <p className="text-sm font-medium">認証状態を確認しています...</p>
+      </div>
+    </main>
+  );
+}
+
+export function ProtectedRoute() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const isLoading = useAuthStore((state) => state.isLoading);
+  const location = useLocation();
+
+  if (isLoading) {
+    return <AuthLoadingScreen />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Navigate
+        replace
+        state={{ from: location } satisfies RedirectState}
+        to="/login"
+      />
+    );
+  }
+
+  return <Outlet />;
+}
+
+export function PublicRoute() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const isLoading = useAuthStore((state) => state.isLoading);
+
+  if (isLoading) {
+    return <AuthLoadingScreen />;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate replace to="/" />;
+  }
+
+  return <Outlet />;
+}

--- a/Shappar/frontend/src/pages/home-page.tsx
+++ b/Shappar/frontend/src/pages/home-page.tsx
@@ -1,0 +1,15 @@
+export function HomePage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div className="space-y-2 text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+          Home
+        </p>
+        <h1 className="text-3xl font-semibold text-slate-950">ホーム</h1>
+        <p className="text-sm text-slate-600">
+          投票一覧などの内容は後続イシューで追加します。
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/Shappar/frontend/src/pages/not-found-page.tsx
+++ b/Shappar/frontend/src/pages/not-found-page.tsx
@@ -1,0 +1,10 @@
+export function NotFoundPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+      <div className="space-y-3 text-center">
+        <h1 className="text-4xl font-semibold text-slate-950">404</h1>
+        <p className="text-sm text-slate-600">ページが見つかりませんでした。</p>
+      </div>
+    </main>
+  );
+}

--- a/Shappar/frontend/src/router.tsx
+++ b/Shappar/frontend/src/router.tsx
@@ -1,0 +1,36 @@
+import { createBrowserRouter, type RouteObject } from 'react-router-dom';
+import { ProtectedRoute, PublicRoute } from '@/components/auth-guard';
+import { HomePage } from '@/pages/home-page';
+import { LoginPage } from '@/pages/login-page';
+import { NotFoundPage } from '@/pages/not-found-page';
+
+export const appRoutes: RouteObject[] = [
+  {
+    path: '/login',
+    element: <PublicRoute />,
+    children: [
+      {
+        index: true,
+        element: <LoginPage />,
+      },
+    ],
+  },
+  {
+    path: '/',
+    element: <ProtectedRoute />,
+    children: [
+      {
+        index: true,
+        element: <HomePage />,
+      },
+    ],
+  },
+  {
+    path: '*',
+    element: <NotFoundPage />,
+  },
+];
+
+export const routes = appRoutes;
+
+export const router = createBrowserRouter(appRoutes);

--- a/Shappar/frontend/src/test/test-utils.tsx
+++ b/Shappar/frontend/src/test/test-utils.tsx
@@ -9,23 +9,45 @@ import {
   type RenderOptions,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { PropsWithChildren, ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ComponentProps, PropsWithChildren, ReactElement } from 'react';
 
-function render(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
+type ExtendedRenderOptions = Omit<RenderOptions, 'wrapper'> & {
+  initialEntries?: ComponentProps<typeof MemoryRouter>['initialEntries'];
+  initialIndex?: number;
+};
+
+function renderWithProviders(
+  ui: ReactElement,
+  options: ExtendedRenderOptions = {},
+) {
+  const { initialEntries, initialIndex, ...renderOptions } = options;
+
   function Wrapper({ children }: PropsWithChildren) {
-    return <>{children}</>;
+    if (!initialEntries) {
+      return <>{children}</>;
+    }
+
+    return (
+      <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+        {children}
+      </MemoryRouter>
+    );
   }
 
   return rtlRender(ui, {
     wrapper: Wrapper,
-    ...options,
+    ...renderOptions,
   });
 }
+
+const render = renderWithProviders;
 
 export {
   cleanup,
   fireEvent,
   render,
+  renderWithProviders,
   renderHook,
   screen,
   userEvent,


### PR DESCRIPTION
## 概要

React Router による `/login` / `/` / `*` のルーティング定義と、Zustand 認証状態に基づく public / protected ガードを追加しました。

## 変更点

- `react-router-dom` を導入し、`src/router.tsx` で `/login`、`/`、`*` を定義
- `ProtectedRoute` / `PublicRoute` を追加して、未認証時の `/login` へのリダイレクトと `location.state.from` の保持、認証済み時の `/` へのリダイレクト、認証初期化中のローディング表示を実装
- `App` を `RouterProvider` ベースに変更し、ホームプレースホルダーと 404 ページを追加
- 認証ガード・ルーター・`App`・テストユーティリティのテストを追加/更新

## 背景 / 目的

- SHA-19 の認証ストアを使って、今後の保護ページ追加に先立つ最小限のルーティング基盤を整えるため
- 未認証時の元パス保持を先に入れておくことで、後続のログイン後リダイレクト実装に繋げるため

## 影響範囲

- 対象画面: `/login`, `/`, 存在しないパス
- 対象ユーザー: 未認証ユーザー、認証済みユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before:
  - なし（ルーター未実装）
- After:
  - 未認証で `/` にアクセスした結果 `/login` に到達
    - ![Unauthenticated redirect](https://raw.githubusercontent.com/Hirochon/Shappar/bff1c39ad4d61f4ca6353bead2134bd3b6b948d5/Shappar/frontend/.artifacts/sha-22/root-redirect.png)
  - `/login` の表示
    - ![Login page](https://raw.githubusercontent.com/Hirochon/Shappar/bff1c39ad4d61f4ca6353bead2134bd3b6b948d5/Shappar/frontend/.artifacts/sha-22/login-page.png)
  - 認証初期化中のローディング表示
    - ![Loading state](https://raw.githubusercontent.com/Hirochon/Shappar/bff1c39ad4d61f4ca6353bead2134bd3b6b948d5/Shappar/frontend/.artifacts/sha-22/loading-spinner.png)

### 操作動画

- なし

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `react-front` に変更がある場合は `build` 実行

## 関連issue

- Linear: SHA-22

## 補足

- reviewer向け確認手順:
  - `cd Shappar/frontend && npm run test:run`
  - `cd Shappar/frontend && npm run build`
- 必要な環境変数やログイン方法:
  - ローカル runtime 検証では Firebase の `auth/invalid-api-key` を避けるため、ダミーの `VITE_FIREBASE_*` 環境変数を注入して起動
  - ローディング画面のスクリーンショットは、未コミットの一時的なローカル proof edit で固定表示して取得済み（最終コードには未包含）

