### PR TITLE
feat: add shared API client foundation

### DIFF
--- a/Shappar/frontend/src/features/auth/use-auth-mutation.ts
+++ b/Shappar/frontend/src/features/auth/use-auth-mutation.ts
@@ -14,10 +14,15 @@ export function useAuthMutation() {
     },
     mutationFn: async (firebaseUser: FirebaseUser) => {
       const idToken = await getIdToken(firebaseUser);
-      const response = await apiClient<AuthResponse>('/api/v1/auth', {
-        method: 'POST',
-        idToken,
-      });
+      const response = await apiClient.post<AuthResponse>(
+        '/api/v1/auth',
+        undefined,
+        {
+          headers: {
+            Authorization: `Bearer ${idToken}`,
+          },
+        },
+      );
 
       return extractAuthUser(response);
     },

--- a/Shappar/frontend/src/lib/__tests__/api-client.test.ts
+++ b/Shappar/frontend/src/lib/__tests__/api-client.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return { auth: mockAuth };
+});
+
+import { ApiError, apiClient } from '@/lib/api-client';
+import { mockAuth, resetFirebaseAuthMocks } from '@/test/mocks/firebase';
+
+function createMockFirebaseUser(
+  overrides: Partial<FirebaseUser> = {},
+): FirebaseUser {
+  return {
+    uid: 'firebase-user-123',
+    email: 'firebase@example.com',
+    displayName: 'Firebase User',
+    ...overrides,
+  } as FirebaseUser;
+}
+
+function createJsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+function getRequestHeaders(init: RequestInit | undefined) {
+  return new Headers(init?.headers);
+}
+
+describe('apiClient', () => {
+  beforeEach(() => {
+    resetFirebaseAuthMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockAuth.currentUser = null;
+  });
+
+  it('uses the configured API base URL when present', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.test');
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(createJsonResponse({ posts: [] }));
+
+    await apiClient.get<{ posts: [] }>('/api/v1/posts/public');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.example.test/api/v1/posts/public',
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to localhost:8040 when no API base URL is configured', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(createJsonResponse({ posts: [] }));
+
+    await apiClient.get<{ posts: [] }>('/api/v1/posts/public');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost:8040/api/v1/posts/public',
+      expect.any(Object),
+    );
+  });
+
+  it('automatically attaches the Firebase ID token as a bearer token', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(createJsonResponse({ posts: [] }));
+    const firebaseUser = createMockFirebaseUser();
+
+    mockAuth.currentUser = firebaseUser;
+    vi.mocked(getIdToken).mockResolvedValueOnce('valid-id-token');
+
+    await apiClient.get<{ posts: [] }>('/api/v1/posts/public');
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = getRequestHeaders(init);
+
+    expect(getIdToken).toHaveBeenCalledTimes(1);
+    expect(getIdToken).toHaveBeenCalledWith(firebaseUser);
+    expect(headers.get('Authorization')).toBe('Bearer valid-id-token');
+  });
+
+  it('serializes JSON request bodies and sets Content-Type automatically', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(createJsonResponse({ post_id: 'post-123' }, { status: 201 }));
+    const payload = {
+      question: 'Where should we go?',
+      options: [
+        { select_num: 1, answer: 'Beach' },
+        { select_num: 2, answer: 'Mountains' },
+      ],
+    };
+
+    await apiClient.post<{ post_id: string }>('/api/v1/posts', payload);
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = getRequestHeaders(init);
+
+    expect(init?.body).toBe(JSON.stringify(payload));
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('parses successful JSON responses', async () => {
+    const responseBody = {
+      posts: [
+        {
+          post_id: 'post-123',
+          question: 'Favorite photo spot?',
+        },
+      ],
+    };
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      createJsonResponse(responseBody),
+    );
+
+    await expect(
+      apiClient.get<typeof responseBody>('/api/v1/posts/public'),
+    ).resolves.toEqual(responseBody);
+  });
+
+  it('throws an ApiError for 401 responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      createJsonResponse(
+        { message: 'Unauthorized' },
+        { status: 401, statusText: 'Unauthorized' },
+      ),
+    );
+
+    let error: unknown;
+
+    try {
+      await apiClient.get('/api/v1/posts/public');
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      status: 401,
+      message: 'Unauthorized',
+      data: { message: 'Unauthorized' },
+    });
+  });
+
+  it.each([
+    [
+      'client error',
+      404,
+      { detail: 'Post not found' },
+      'Post not found',
+    ],
+    [
+      'server error',
+      500,
+      { message: 'Internal Server Error' },
+      'Internal Server Error',
+    ],
+  ])(
+    'throws an ApiError for %s responses',
+    async (_label, status, responseBody, message) => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        createJsonResponse(responseBody, { status }),
+      );
+
+      let error: unknown;
+
+      try {
+        await apiClient.get('/api/v1/posts/public');
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({
+        status,
+        message,
+        data: responseBody,
+      });
+    },
+  );
+
+  it('wraps network failures in an ApiError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new TypeError('Failed to fetch'),
+    );
+
+    let error: unknown;
+
+    try {
+      await apiClient.get('/api/v1/posts/public');
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      status: 0,
+      message: 'Failed to fetch',
+      data: null,
+    });
+  });
+});

--- a/Shappar/frontend/src/lib/__tests__/query-client.test.ts
+++ b/Shappar/frontend/src/lib/__tests__/query-client.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { createQueryClient } from '@/lib/query-client';
+
+describe('createQueryClient', () => {
+  it('configures the default query and mutation options', () => {
+    const queryClient = createQueryClient();
+    const defaultOptions = queryClient.getDefaultOptions();
+
+    expect(defaultOptions.queries).toMatchObject({
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    });
+    expect(defaultOptions.mutations).toMatchObject({
+      retry: 0,
+    });
+  });
+
+  it('uses the expected retry policy for queries and mutations', () => {
+    const queryClient = createQueryClient();
+    const defaultOptions = queryClient.getDefaultOptions();
+
+    expect(defaultOptions.queries?.retry).toBe(1);
+    expect(defaultOptions.mutations?.retry).toBe(0);
+  });
+});

--- a/Shappar/frontend/src/lib/api-client.ts
+++ b/Shappar/frontend/src/lib/api-client.ts
@@ -1,22 +1,24 @@
+import { getIdToken } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
+
 const DEFAULT_API_BASE_URL = 'http://localhost:8040';
 
-type ApiClientOptions = RequestInit & {
-  idToken?: string;
-};
-
 type ErrorResponseBody = {
+  detail?: string;
   message?: string;
 };
 
 export class ApiError extends Error {
   readonly status: number;
+  readonly data: unknown;
   readonly body: unknown;
 
-  constructor(message: string, status: number, body: unknown) {
+  constructor(message: string, status: number, data: unknown) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
-    this.body = body;
+    this.data = data;
+    this.body = data;
   }
 }
 
@@ -24,18 +26,31 @@ function getApiBaseUrl() {
   return import.meta.env.VITE_API_BASE_URL ?? DEFAULT_API_BASE_URL;
 }
 
-function buildHeaders({ body, headers, idToken }: ApiClientOptions) {
+function serializeBody(body: unknown) {
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+
+  if (body instanceof FormData) {
+    return body;
+  }
+
+  return JSON.stringify(body);
+}
+
+async function buildHeaders(
+  headers: HeadersInit | undefined,
+  body: unknown,
+) {
   const requestHeaders = new Headers(headers);
 
-  if (
-    body &&
-    !(body instanceof FormData) &&
-    !requestHeaders.has('Content-Type')
-  ) {
+  if (body !== undefined && body !== null && !(body instanceof FormData)) {
     requestHeaders.set('Content-Type', 'application/json');
   }
 
-  if (idToken) {
+  if (!requestHeaders.has('Authorization') && auth.currentUser) {
+    const idToken = await getIdToken(auth.currentUser);
+
     requestHeaders.set('Authorization', `Bearer ${idToken}`);
   }
 
@@ -47,49 +62,109 @@ async function parseResponseBody(response: Response): Promise<unknown> {
     return null;
   }
 
+  const text = await response.text();
+
+  if (text.length === 0) {
+    return null;
+  }
+
   const contentType = response.headers.get('content-type') ?? '';
 
   if (contentType.includes('application/json')) {
-    const json: unknown = await response.json();
-
-    return json;
+    return JSON.parse(text) as unknown;
   }
 
-  const text = await response.text();
-
-  return text.length > 0 ? text : null;
+  return text;
 }
 
-function getErrorMessage(status: number, body: unknown) {
-  if (
-    body &&
-    typeof body === 'object' &&
-    'message' in body &&
-    typeof (body as ErrorResponseBody).message === 'string'
-  ) {
-    return (body as ErrorResponseBody).message!;
+function getErrorMessage(status: number, data: unknown) {
+  if (typeof data === 'string' && data.length > 0) {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    if (
+      'message' in data &&
+      typeof (data as ErrorResponseBody).message === 'string'
+    ) {
+      return (data as ErrorResponseBody).message!;
+    }
+
+    if (
+      'detail' in data &&
+      typeof (data as ErrorResponseBody).detail === 'string'
+    ) {
+      return (data as ErrorResponseBody).detail!;
+    }
+  }
+
+  if (status === 401) {
+    return 'Unauthorized';
   }
 
   return `Request failed with status ${status}`;
 }
 
-export async function apiClient<T>(
-  path: string,
-  options: ApiClientOptions = {},
-) {
-  const response = await fetch(new URL(path, getApiBaseUrl()).toString(), {
-    ...options,
-    headers: buildHeaders(options),
-  });
-  const body = await parseResponseBody(response);
-
-  if (!response.ok) {
-    throw new ApiError(
-      getErrorMessage(response.status, body),
-      response.status,
-      body,
-    );
+function getUnexpectedErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
   }
 
-  return body as T;
+  return 'Network request failed';
 }
+
+async function request<T>(path: string, options: RequestInit = {}) {
+  try {
+    const response = await fetch(new URL(path, getApiBaseUrl()).toString(), {
+      ...options,
+      body: options.body,
+      headers: await buildHeaders(options.headers, options.body),
+    });
+    const data = await parseResponseBody(response);
+
+    if (!response.ok) {
+      throw new ApiError(
+        getErrorMessage(response.status, data),
+        response.status,
+        data,
+      );
+    }
+
+    return data as T;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    throw new ApiError(getUnexpectedErrorMessage(error), 0, null);
+  }
+}
+
+export const apiClient = {
+  get<T>(path: string, options?: RequestInit) {
+    return request<T>(path, {
+      ...options,
+      method: 'GET',
+    });
+  },
+  post<T>(path: string, body: unknown, options?: RequestInit) {
+    return request<T>(path, {
+      ...options,
+      body: serializeBody(body),
+      method: 'POST',
+    });
+  },
+  patch<T>(path: string, body: unknown, options?: RequestInit) {
+    return request<T>(path, {
+      ...options,
+      body: serializeBody(body),
+      method: 'PATCH',
+    });
+  },
+  delete<T>(path: string, options?: RequestInit) {
+    return request<T>(path, {
+      ...options,
+      method: 'DELETE',
+    });
+  },
+};

--- a/Shappar/frontend/src/lib/query-client.ts
+++ b/Shappar/frontend/src/lib/query-client.ts
@@ -4,10 +4,12 @@ export function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        retry: false,
+        staleTime: 1000 * 60 * 5,
+        retry: 1,
+        refetchOnWindowFocus: false,
       },
       mutations: {
-        retry: false,
+        retry: 0,
       },
     },
   });

--- a/Shappar/frontend/src/types/api.ts
+++ b/Shappar/frontend/src/types/api.ts
@@ -1,0 +1,28 @@
+export interface PostOption {
+  select_num: number;
+  answer: string;
+  votes?: number;
+}
+
+export interface Post {
+  post_id: string;
+  user_id: string;
+  iconimage: string;
+  question: string;
+  voted: boolean;
+  options: PostOption[];
+  created_at: string;
+  selected_num: number;
+  total: number;
+}
+
+export interface User {
+  user_id: string;
+  name: string;
+  introduction: string;
+  homeImage: string;
+  iconimage: string;
+  followers: number;
+  follow: number;
+  followed: boolean;
+}


### PR DESCRIPTION
## 概要

TanStack Query の API クライアント基盤を拡張し、共通の認証ヘッダー付与・JSON 処理・エラーハンドリング・QueryClient デフォルト設定を追加しました。

## 変更点

- `apiClient` を型付き `get/post/patch/delete` API に変更
- Firebase `currentUser` からの Bearer token 自動付与と `ApiError` の共通化を追加
- QueryClient の `staleTime` / retry / `refetchOnWindowFocus` を標準化
- API 共通型と `api-client` / `query-client` の Vitest を追加
- auth mutation を新しい `apiClient.post` 呼び出しに追従

## 背景 / 目的

SHA-24 の目的である API クライアント共通基盤の整備に合わせ、今後の posts / users / friendships 系エンドポイントが同一の基盤を使える状態にするためです。

## 影響範囲

- 対象画面: ログイン後の API 呼び出し全般（主に認証 API 連携基盤）
- 対象ユーザー: フロントエンドの API 呼び出し経路を利用する全ユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: なし
- After: なし

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [x] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `react-front` に変更がある場合は `build` 実行

## 関連issue

- SHA-24 https://linear.app/shappar/issue/SHA-24/api-クライアント基盤tanstack-query-設定

## 補足

- reviewer向け確認手順: `cd Shappar/frontend && npm run test:run -- src/lib/__tests__/api-client.test.ts src/lib/__tests__/query-client.test.ts && npm run test:run && npm run build`
- 必要な環境変数やログイン方法: 通常の frontend 開発用 `.env` と Firebase 設定
