### PR TITLE
feat(frontend): add error boundary and API error handling

### DIFF
--- a/Shappar/frontend/src/App.test.tsx
+++ b/Shappar/frontend/src/App.test.tsx
@@ -12,6 +12,12 @@ const authStoreMocks = vi.hoisted(() => {
   return { initAuthListener, routerProvider, unsubscribe };
 });
 
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return { auth: mockAuth };
+});
 vi.mock('@/stores/auth-store', () => ({
   useAuthStore: (selector: (state: { initAuthListener: () => () => void }) => unknown) =>
     selector({ initAuthListener: authStoreMocks.initAuthListener }),

--- a/Shappar/frontend/src/App.tsx
+++ b/Shappar/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
+import { ErrorBoundary } from '@/components/error-boundary';
 import { router } from '@/router';
 import { queryClient } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
@@ -14,7 +15,9 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <ErrorBoundary>
+        <RouterProvider router={router} />
+      </ErrorBoundary>
     </QueryClientProvider>
   );
 }

--- a/Shappar/frontend/src/components/__tests__/error-boundary.test.tsx
+++ b/Shappar/frontend/src/components/__tests__/error-boundary.test.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from '@/components/error-boundary';
+import { render, screen, userEvent, waitFor } from '@/test/test-utils';
+
+function ThrowingComponent(): never {
+  throw new Error('render failed');
+}
+
+function StableComponent() {
+  return <p>正常なコンテンツ</p>;
+}
+
+function RecoverableComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('recoverable failure');
+  }
+
+  return <p>復旧後のコンテンツ</p>;
+}
+
+function RecoverableBoundaryHarness() {
+  const [shouldThrow, setShouldThrow] = useState(true);
+
+  return (
+    <ErrorBoundary
+      onReset={() => {
+        setShouldThrow(false);
+      }}
+    >
+      <RecoverableComponent shouldThrow={shouldThrow} />
+    </ErrorBoundary>
+  );
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the fallback UI when a child component throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '再試行' })).toBeInTheDocument();
+    expect(screen.queryByText('正常なコンテンツ')).not.toBeInTheDocument();
+  });
+
+  it('shows the expected fallback message', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('resets the boundary when retry is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<RecoverableBoundaryHarness />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: '再試行',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('復旧後のコンテンツ')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('エラーが発生しました')).not.toBeInTheDocument();
+  });
+
+  it('renders children normally when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <StableComponent />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('正常なコンテンツ')).toBeInTheDocument();
+    expect(screen.queryByText('エラーが発生しました')).not.toBeInTheDocument();
+  });
+});

--- a/Shappar/frontend/src/components/__tests__/error-display.test.tsx
+++ b/Shappar/frontend/src/components/__tests__/error-display.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ErrorDisplay } from '@/components/error-display';
+import { render, screen, userEvent } from '@/test/test-utils';
+
+describe('ErrorDisplay', () => {
+  it('shows the error message', () => {
+    render(<ErrorDisplay message="データの取得に失敗しました。" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'データの取得に失敗しました。',
+    );
+  });
+
+  it('calls onRetry when the retry button is clicked', async () => {
+    const onRetry = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ErrorDisplay
+        message="データの取得に失敗しました。"
+        onRetry={onRetry}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: '再試行',
+      }),
+    );
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Shappar/frontend/src/components/error-boundary.tsx
+++ b/Shappar/frontend/src/components/error-boundary.tsx
@@ -1,0 +1,82 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  onReset?: () => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  hasError: boolean;
+}
+
+const initialState: ErrorBoundaryState = {
+  error: null,
+  hasError: false,
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  override state: ErrorBoundaryState = initialState;
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      error,
+      hasError: true,
+    };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Unhandled render error', error, errorInfo);
+  }
+
+  private readonly handleReset = () => {
+    if (this.props.onReset) {
+      this.props.onReset();
+      this.setState(initialState);
+      return;
+    }
+
+    window.location.reload();
+  };
+
+  override render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[radial-gradient(circle_at_top,_rgba(248,113,113,0.12),_transparent_38%),linear-gradient(180deg,_#fff7ed_0%,_#fffbeb_100%)] px-4 py-10">
+        <Card className="w-full max-w-lg border-destructive/20 bg-white/95 shadow-[0_28px_80px_rgba(124,45,18,0.14)]">
+          <CardHeader className="space-y-3">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-700">
+              Unexpected Error
+            </p>
+            <CardTitle className="text-3xl text-slate-950">
+              エラーが発生しました
+            </CardTitle>
+            <CardDescription className="text-base leading-7 text-slate-600">
+              画面の表示中に問題が発生しました。再試行しても改善しない場合は、
+              ページを再読み込みしてください。
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={this.handleReset} type="button">
+              再試行
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+}

--- a/Shappar/frontend/src/components/error-display.tsx
+++ b/Shappar/frontend/src/components/error-display.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button';
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@/components/ui/alert';
+
+interface ErrorDisplayProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export function ErrorDisplay({ message, onRetry }: ErrorDisplayProps) {
+  return (
+    <Alert className="space-y-3" variant="destructive">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <AlertTitle>エラー</AlertTitle>
+          <AlertDescription>{message}</AlertDescription>
+        </div>
+        {onRetry ? (
+          <Button
+            className="shrink-0 self-start"
+            onClick={onRetry}
+            type="button"
+            variant="outline"
+          >
+            再試行
+          </Button>
+        ) : null}
+      </div>
+    </Alert>
+  );
+}

--- a/Shappar/frontend/src/components/ui/alert.tsx
+++ b/Shappar/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/lib/utils'
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm [&>p]:leading-relaxed',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/30 bg-destructive/10 text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(alertVariants({ variant }), className)}
+    role="alert"
+    {...props}
+  />
+))
+Alert.displayName = 'Alert'
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-semibold tracking-tight', className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = 'AlertTitle'
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm', className)} {...props} />
+))
+AlertDescription.displayName = 'AlertDescription'
+
+export { Alert, AlertDescription, AlertTitle }

--- a/Shappar/frontend/src/hooks/__tests__/use-api-error-handler.test.ts
+++ b/Shappar/frontend/src/hooks/__tests__/use-api-error-handler.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const authStoreState = vi.hoisted(() => ({
+  clearUser: vi.fn(),
+  clearAuthUser: vi.fn(),
+}));
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return { auth: mockAuth };
+});
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/stores/auth-store', () => {
+  const useAuthStore = Object.assign(
+    (selector: (state: typeof authStoreState) => unknown) =>
+      selector(authStoreState),
+    {
+      getState: () => authStoreState,
+    },
+  );
+
+  return { useAuthStore };
+});
+
+import { ApiError } from '@/lib/api-client';
+import { useApiErrorHandler } from '@/hooks/use-api-error-handler';
+import { renderHook } from '@/test/test-utils';
+
+describe('useApiErrorHandler', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    authStoreState.clearUser.mockReset();
+    authStoreState.clearAuthUser.mockReset();
+  });
+
+  it('clears the auth store and redirects to /login on 401 errors', () => {
+    const { result } = renderHook(() => useApiErrorHandler());
+
+    result.current(new ApiError('Unauthorized', 401, { message: 'Unauthorized' }));
+
+    expect(authStoreState.clearUser).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/login', { replace: true });
+  });
+
+  it('returns a permission error message for 403 errors', () => {
+    const { result } = renderHook(() => useApiErrorHandler());
+
+    expect(
+      result.current(new ApiError('Forbidden', 403, { message: 'Forbidden' })),
+    ).toBe('権限がありません');
+  });
+
+  it('returns a not found message for 404 errors', () => {
+    const { result } = renderHook(() => useApiErrorHandler());
+
+    expect(
+      result.current(new ApiError('Not Found', 404, { message: 'Not Found' })),
+    ).toBe('見つかりませんでした');
+  });
+
+  it('returns a server error message for 500 errors', () => {
+    const { result } = renderHook(() => useApiErrorHandler());
+
+    expect(
+      result.current(
+        new ApiError('Internal Server Error', 500, {
+          message: 'Internal Server Error',
+        }),
+      ),
+    ).toBe('サーバーエラーが発生しました');
+  });
+
+  it('returns a network error message for network errors', () => {
+    const { result } = renderHook(() => useApiErrorHandler());
+
+    expect(result.current(new ApiError('Failed to fetch', 0, null))).toBe(
+      'ネットワーク接続を確認してください',
+    );
+  });
+});

--- a/Shappar/frontend/src/hooks/use-api-error-handler.ts
+++ b/Shappar/frontend/src/hooks/use-api-error-handler.ts
@@ -1,0 +1,89 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ApiError } from '@/lib/api-client';
+import { useAuthStore } from '@/stores/auth-store';
+
+const UNAUTHORIZED_MESSAGE =
+  '認証の有効期限が切れました。再度ログインしてください。';
+const FORBIDDEN_MESSAGE = '権限がありません';
+const NOT_FOUND_MESSAGE = '見つかりませんでした';
+const SERVER_ERROR_MESSAGE = 'サーバーエラーが発生しました';
+const NETWORK_ERROR_MESSAGE = 'ネットワーク接続を確認してください';
+const DEFAULT_ERROR_MESSAGE = '予期しないエラーが発生しました';
+
+function isNetworkError(error: unknown) {
+  return (
+    error instanceof TypeError ||
+    (error instanceof ApiError && error.status === 0)
+  );
+}
+
+function clearAuthSession() {
+  useAuthStore.getState().clearUser();
+}
+
+function redirectToLogin() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (window.location.pathname === '/login') {
+    return;
+  }
+
+  window.history.replaceState(null, '', '/login');
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function getApiErrorMessage(error: unknown) {
+  if (isNetworkError(error)) {
+    return NETWORK_ERROR_MESSAGE;
+  }
+
+  if (error instanceof ApiError) {
+    switch (error.status) {
+      case 401:
+        return UNAUTHORIZED_MESSAGE;
+      case 403:
+        return FORBIDDEN_MESSAGE;
+      case 404:
+        return NOT_FOUND_MESSAGE;
+      case 500:
+        return SERVER_ERROR_MESSAGE;
+      default:
+        return error.message || DEFAULT_ERROR_MESSAGE;
+    }
+  }
+
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return DEFAULT_ERROR_MESSAGE;
+}
+
+export function handleGlobalApiError(error: unknown) {
+  if (error instanceof ApiError && error.status === 401) {
+    clearAuthSession();
+    redirectToLogin();
+  }
+
+  return getApiErrorMessage(error);
+}
+
+export function useApiErrorHandler() {
+  const clearUser = useAuthStore((state) => state.clearUser);
+  const navigate = useNavigate();
+
+  return useCallback(
+    (error: unknown) => {
+      if (error instanceof ApiError && error.status === 401) {
+        clearUser();
+        void navigate('/login', { replace: true });
+      }
+
+      return getApiErrorMessage(error);
+    },
+    [clearUser, navigate],
+  );
+}

--- a/Shappar/frontend/src/lib/__tests__/query-client.test.ts
+++ b/Shappar/frontend/src/lib/__tests__/query-client.test.ts
@@ -1,7 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const clearUserMock = vi.hoisted(() => vi.fn());
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return { auth: mockAuth };
+});
+vi.mock('@/stores/auth-store', () => {
+  const useAuthStore = Object.assign(
+    (selector: (state: { clearUser: () => void }) => unknown) =>
+      selector({ clearUser: clearUserMock }),
+    {
+      getState: () => ({
+        clearUser: clearUserMock,
+      }),
+    },
+  );
+
+  return { useAuthStore };
+});
+
+import { ApiError } from '@/lib/api-client';
 import { createQueryClient } from '@/lib/query-client';
 
 describe('createQueryClient', () => {
+  afterEach(() => {
+    clearUserMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
   it('configures the default query and mutation options', () => {
     const queryClient = createQueryClient();
     const defaultOptions = queryClient.getDefaultOptions();
@@ -22,5 +51,31 @@ describe('createQueryClient', () => {
 
     expect(defaultOptions.queries?.retry).toBe(1);
     expect(defaultOptions.mutations?.retry).toBe(0);
+  });
+
+  it('registers global query and mutation error handlers', () => {
+    const queryClient = createQueryClient();
+
+    expect(queryClient.getQueryCache().config.onError).toEqual(
+      expect.any(Function),
+    );
+    expect(queryClient.getMutationCache().config.onError).toEqual(
+      expect.any(Function),
+    );
+  });
+
+  it('clears auth state and redirects on global 401 query errors', () => {
+    const queryClient = createQueryClient();
+    const initialPath = window.location.pathname;
+
+    queryClient.getQueryCache().config.onError?.(
+      new ApiError('Unauthorized', 401, { message: 'Unauthorized' }),
+      {} as never,
+    );
+
+    expect(clearUserMock).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe('/login');
+
+    window.history.replaceState(null, '', initialPath);
   });
 });

--- a/Shappar/frontend/src/lib/query-client.ts
+++ b/Shappar/frontend/src/lib/query-client.ts
@@ -1,7 +1,18 @@
-import { QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+import { handleGlobalApiError } from '@/hooks/use-api-error-handler';
 
 export function createQueryClient() {
   return new QueryClient({
+    mutationCache: new MutationCache({
+      onError: (error) => {
+        handleGlobalApiError(error);
+      },
+    }),
+    queryCache: new QueryCache({
+      onError: (error) => {
+        handleGlobalApiError(error);
+      },
+    }),
     defaultOptions: {
       queries: {
         staleTime: 1000 * 60 * 5,

--- a/Shappar/frontend/src/pages/login-page.tsx
+++ b/Shappar/frontend/src/pages/login-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { signInWithPopup } from 'firebase/auth';
+import { ErrorDisplay } from '@/components/error-display';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -123,12 +124,12 @@ export function LoginPage() {
               )}
             </Button>
             {error ? (
-              <p
-                className="rounded-lg border border-destructive/20 bg-destructive/10 px-4 py-3 text-sm text-destructive"
-                role="alert"
-              >
-                {error}
-              </p>
+              <ErrorDisplay
+                message={error}
+                onRetry={() => {
+                  void handleGoogleLogin();
+                }}
+              />
             ) : null}
           </CardContent>
         </Card>


### PR DESCRIPTION
## 概要

React Error Boundary と API エラーの共通ハンドリングを追加し、401 の
セッション切れをグローバルに `/login` へ戻すようにしました。

## 変更点

- ErrorBoundary / ErrorDisplay / Alert UI と関連テストを追加
- `useApiErrorHandler` と QueryClient のグローバル 401 handling を追加
- `App.tsx` を ErrorBoundary でラップし、login page のエラー表示を共通化
- `query-client` と `App` の既存テストを更新

## 背景 / 目的

予期しない描画エラーや API 失敗時にアプリが無反応になるのを防ぎ、
ユーザーに recovery path を提示するためです。

## 影響範囲

- 対象画面: アプリ全体、`/login`
- 対象ユーザー: フロントエンド利用者全体
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: 描画例外の fallback UI がなく、login page のエラー表示は個別実装
- After: ErrorBoundary の fallback card と共通 ErrorDisplay を追加

### 操作動画

- CLI セッションのため未添付

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [ ] ローカルで対象画面を確認
- [ ] 主要導線を一通り操作
- [x] `react-front` に変更がある場合は `build` 実行
- [x] `cd Shappar/frontend && npm run lint`
- [x] `cd Shappar/frontend && npm run test:run`
- [x] `cd Shappar/frontend && npm run build`

## 関連issue

- SHA-25

## 補足

- reviewer向け確認手順:
  - `cd Shappar/frontend && npm run test:run`
  - `cd Shappar/frontend && npm run build`
  - 401 時の `/login` 遷移と ErrorBoundary fallback をコード/テストで確認
- 必要な環境変数やログイン方法:
  - `Shappar/frontend/.env.example` 相当の Firebase / API 環境変数
