### PR TITLE
shappar-api の OpenAPI ハンドラ骨組みを追加

### DIFF
--- a/go-server/apps/shappar-api/cmd/di.go
+++ b/go-server/apps/shappar-api/cmd/di.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"github.com/Hirochon/Shappar/apps/shappar-api/gateway/handler"
 	"github.com/Hirochon/Shappar/core/util/config"
 	"github.com/samber/do"
 )
 
 type injected struct {
-	// handler    *handler.Handler
+	handler *handler.Handler
 	// middleware *middleware.Middleware
 	httpConf *config.HTTP
 	shutdown func() error
@@ -23,11 +24,11 @@ func inject() *injected {
 	// http.InjectForAuthAPI(i)
 	// service.InjectForAuthAPI(i)
 	// usecase.Inject(i)
-	// handler.Inject(i)
+	handler.Inject(i)
 	// middleware.Inject(i)
 
 	return &injected{
-		// handler:    do.MustInvoke[*handler.Handler](i),
+		handler: do.MustInvoke[*handler.Handler](i),
 		// middleware: do.MustInvoke[*middleware.Middleware](i),
 		httpConf: do.MustInvoke[*config.HTTP](i),
 		shutdown: i.Shutdown,

--- a/go-server/apps/shappar-api/cmd/server.go
+++ b/go-server/apps/shappar-api/cmd/server.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	// "github.com/ca-pigg/amphora-server/apps/auth-api/gateway/oas"
+	"github.com/Hirochon/Shappar/apps/shappar-api/gateway/oas"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/riandyrn/otelchi"
@@ -28,17 +28,10 @@ func newServer(injected *injected) *http.Server {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	// h := oas.HandlerWithOptions(injected.handler, oas.ChiServerOptions{
-	// 	BaseURL:    "/v1",
-	// 	BaseRouter: r,
-	// 	Middlewares: []oas.MiddlewareFunc{
-	// 		injected.middleware.Authenticate,
-	// 		injected.middleware.AccessLogger,
-	// 		injected.middleware.SetClient,
-	// 	},
-	// })
-
-	h := r
+	h := oas.HandlerWithOptions(injected.handler, oas.ChiServerOptions{
+		BaseURL:    "/v1",
+		BaseRouter: r,
+	})
 
 	return &http.Server{
 		Addr:    fmt.Sprintf(":%d", injected.httpConf.Port),

--- a/go-server/apps/shappar-api/gateway/handler/di.go
+++ b/go-server/apps/shappar-api/gateway/handler/di.go
@@ -1,0 +1,7 @@
+package handler
+
+import "github.com/samber/do"
+
+func Inject(i *do.Injector) {
+	do.Provide(i, New)
+}

--- a/go-server/apps/shappar-api/gateway/handler/handler.go
+++ b/go-server/apps/shappar-api/gateway/handler/handler.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Hirochon/Shappar/apps/shappar-api/gateway/oas"
+	"github.com/samber/do"
+)
+
+var _ oas.ServerInterface = (*Handler)(nil)
+
+type Handler struct {
+	oas.Unimplemented
+	// uc usecase.Usecase
+}
+
+// DeleteApiV1FriendshipsUserId implements [oas.ServerInterface].
+func (h *Handler) DeleteApiV1FriendshipsUserId(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// DeleteApiV1PostsPostId implements [oas.ServerInterface].
+func (h *Handler) DeleteApiV1PostsPostId(w http.ResponseWriter, r *http.Request, postId string) {
+	panic("unimplemented")
+}
+
+// DeleteApiV1UsersUserId implements [oas.ServerInterface].
+func (h *Handler) DeleteApiV1UsersUserId(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1FrendshipsUserIdFollowers implements [oas.ServerInterface].
+func (h *Handler) GetApiV1FrendshipsUserIdFollowers(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1FrendshipsUserIdFollowing implements [oas.ServerInterface].
+func (h *Handler) GetApiV1FrendshipsUserIdFollowing(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1Health implements [oas.ServerInterface].
+func (h *Handler) GetApiV1Health(w http.ResponseWriter, r *http.Request) {
+	panic("unimplemented")
+}
+
+// GetApiV1PostsPostId implements [oas.ServerInterface].
+func (h *Handler) GetApiV1PostsPostId(w http.ResponseWriter, r *http.Request, postId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1PostsPrivate implements [oas.ServerInterface].
+func (h *Handler) GetApiV1PostsPrivate(w http.ResponseWriter, r *http.Request, params oas.GetApiV1PostsPrivateParams) {
+	panic("unimplemented")
+}
+
+// GetApiV1PostsPublic implements [oas.ServerInterface].
+func (h *Handler) GetApiV1PostsPublic(w http.ResponseWriter, r *http.Request, params oas.GetApiV1PostsPublicParams) {
+	panic("unimplemented")
+}
+
+// GetApiV1PostsPublicPostId implements [oas.ServerInterface].
+func (h *Handler) GetApiV1PostsPublicPostId(w http.ResponseWriter, r *http.Request, postId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1PostsPublicRank implements [oas.ServerInterface].
+func (h *Handler) GetApiV1PostsPublicRank(w http.ResponseWriter, r *http.Request) {
+	panic("unimplemented")
+}
+
+// GetApiV1Users implements [oas.ServerInterface].
+func (h *Handler) GetApiV1Users(w http.ResponseWriter, r *http.Request) {
+	panic("unimplemented")
+}
+
+// GetApiV1UsersUserId implements [oas.ServerInterface].
+func (h *Handler) GetApiV1UsersUserId(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1UsersUserIdPosted implements [oas.ServerInterface].
+func (h *Handler) GetApiV1UsersUserIdPosted(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1UsersUserIdSettings implements [oas.ServerInterface].
+func (h *Handler) GetApiV1UsersUserIdSettings(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// GetApiV1UsersUserIdVoted implements [oas.ServerInterface].
+func (h *Handler) GetApiV1UsersUserIdVoted(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// PatchApiV1UsersUserId implements [oas.ServerInterface].
+func (h *Handler) PatchApiV1UsersUserId(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// PostApiV1FriendshipsUserId implements [oas.ServerInterface].
+func (h *Handler) PostApiV1FriendshipsUserId(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// PostApiV1Posts implements [oas.ServerInterface].
+func (h *Handler) PostApiV1Posts(w http.ResponseWriter, r *http.Request) {
+	panic("unimplemented")
+}
+
+// PostApiV1PostsPostIdPolls implements [oas.ServerInterface].
+func (h *Handler) PostApiV1PostsPostIdPolls(w http.ResponseWriter, r *http.Request, postId string) {
+	panic("unimplemented")
+}
+
+// PostApiV1Users implements [oas.ServerInterface].
+func (h *Handler) PostApiV1Users(w http.ResponseWriter, r *http.Request) {
+	panic("unimplemented")
+}
+
+// PutApiV1FriendshipsUserId implements [oas.ServerInterface].
+func (h *Handler) PutApiV1FriendshipsUserId(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+// PutApiV1UsersUserIdSettings implements [oas.ServerInterface].
+func (h *Handler) PutApiV1UsersUserIdSettings(w http.ResponseWriter, r *http.Request, userId string) {
+	panic("unimplemented")
+}
+
+func New(i *do.Injector) (*Handler, error) {
+	return &Handler{
+		// uc: do.MustInvoke[usecase.Usecase](i),
+	}, nil
+}


### PR DESCRIPTION
## 概要
shappar-api で OpenAPI 生成コードを利用するためのハンドラ骨組みと DI 配線を追加し、サーバー起動時に `oas.HandlerWithOptions` を経由してルーティングされる状態にしました。

## 変更点
- `gateway/handler` パッケージを追加し、`oas.ServerInterface` を満たす `Handler` を定義
- DI で `handler.Handler` を注入するように変更
- サーバー起動処理で `oas.HandlerWithOptions` を使って `/v1` 配下の OpenAPI ルートを登録
- 各 API エンドポイントのメソッドをハンドラ側に生成し、今後の実装先を明確化

## 背景 / 目的
これまで `shappar-api` では OpenAPI 生成コードは存在していたものの、実際のハンドラが DI / ルータに配線されておらず、実装を進めるための入口が不足していました。まずは ServerInterface の受け口を揃えて、今後ユースケースやミドルウェアを接続していける土台を作るのが目的です。

## 影響範囲
- 対象画面: なし
- 対象ユーザー: shappar-api を開発・保守する開発者
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり
- Before: なし
- After: なし

### 操作動画
- なし

### UI変更なし
- [x] UI変更なし

## 確認項目
- [ ] ローカルで対象画面を確認（バックエンド変更のみのため未実施）
- [ ] 主要導線を一通り操作（各 API は未実装のため未実施）
- [ ] `react-front` に変更がある場合は `build` 実行（該当なし）
- [x] `cd go-server && go test ./...`

## 関連issue
なし

## 補足
- reviewer向け確認手順: `go-server/apps/shappar-api/cmd/server.go` で `oas.HandlerWithOptions` が使われていること、および `go-server/apps/shappar-api/gateway/handler/handler.go` に各エンドポイントの受け口が追加されていることを確認してください。
- 必要な環境変数やログイン方法: `go test` 実行時は `ENV=test` がテスト内で設定されます。
- 各エンドポイントの実処理はまだ未実装で、現時点では `panic("unimplemented")` のスタブです。後続で usecase / middleware を接続していく前提です。
