### PR TITLE
SHA-35 frontend build の bundle size warning を解消する

### DIFF
--- a/Shappar/frontend/vite.config.ts
+++ b/Shappar/frontend/vite.config.ts
@@ -5,6 +5,50 @@ import { defineConfig } from 'vitest/config';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        // Split heavy vendors so the app entry bundle stays below Vite's warning threshold.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return undefined;
+          }
+
+          if (id.includes('/@firebase/') || id.includes('/firebase/')) {
+            return 'vendor-firebase';
+          }
+
+          if (id.includes('/react-router/') || id.includes('/react-router-dom/')) {
+            return 'vendor-router';
+          }
+
+          if (
+            id.includes('/@radix-ui/') ||
+            id.includes('/@floating-ui/') ||
+            id.includes('/class-variance-authority/') ||
+            id.includes('/clsx/') ||
+            id.includes('/tailwind-merge/')
+          ) {
+            return 'vendor-ui';
+          }
+
+          if (id.includes('/@tanstack/')) {
+            return 'vendor-query';
+          }
+
+          if (
+            id.includes('/react/') ||
+            id.includes('/react-dom/') ||
+            id.includes('/scheduler/')
+          ) {
+            return 'vendor-react';
+          }
+
+          return 'vendor-misc';
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## 概要

Vite build で 500 kB を超えていた frontend の entry chunk warning を、vendor chunk splitting で解消しました。

## 変更点

- `Shappar/frontend/vite.config.ts` に `manualChunks` を追加
- `@firebase/auth`、`react-router`、`react`/`react-dom`、UI 系依存、React Query を個別 chunk に分離
- build 出力を warning threshold 未満の chunk 構成へ整理

## 背景 / 目的

- `npm run build` で `dist/assets/index-*.js` が 562.83 kB となり Vite warning が発生していた
- source map 解析で `@firebase/auth`、`react-router`、`react-dom` が単一 chunk に集中していることを確認した

## 影響範囲

- 対象画面: frontend build output のみ
- 対象ユーザー: frontend build / deploy を行う開発者
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before:
- After:

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [x] UI変更なし

## 確認項目

- [ ] ローカルで対象画面を確認
- [ ] 主要導線を一通り操作
- [x] `react-front` に変更がある場合は `build` 実行

## 関連issue

- Linear: SHA-35

## 補足

- reviewer向け確認手順:
  - `cd Shappar/frontend && npm run build`
  - `cd Shappar/frontend && npm run lint`
  - `cd Shappar/frontend && npm run test:run`
- 必要な環境変数やログイン方法:
  - なし。build config のみの変更です
