### PR TITLE
feat(api): shappar-api にミドルウェア基盤とアクセスログを追加

### DIFF
--- a/go-server/apps/shappar-api/cmd/di.go
+++ b/go-server/apps/shappar-api/cmd/di.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"github.com/Hirochon/Shappar/apps/shappar-api/gateway/handler"
+	"github.com/Hirochon/Shappar/apps/shappar-api/gateway/middleware"
 	"github.com/Hirochon/Shappar/core/util/config"
 	"github.com/samber/do"
 )
 
 type injected struct {
-	handler *handler.Handler
-	// middleware *middleware.Middleware
-	httpConf *config.HTTP
-	shutdown func() error
+	handler    *handler.Handler
+	middleware *middleware.Middleware
+	httpConf   *config.HTTP
+	shutdown   func() error
 }
 
 func inject() *injected {
@@ -25,12 +26,12 @@ func inject() *injected {
 	// service.InjectForAuthAPI(i)
 	// usecase.Inject(i)
 	handler.Inject(i)
-	// middleware.Inject(i)
+	middleware.Inject(i)
 
 	return &injected{
-		handler: do.MustInvoke[*handler.Handler](i),
-		// middleware: do.MustInvoke[*middleware.Middleware](i),
-		httpConf: do.MustInvoke[*config.HTTP](i),
-		shutdown: i.Shutdown,
+		handler:    do.MustInvoke[*handler.Handler](i),
+		middleware: do.MustInvoke[*middleware.Middleware](i),
+		httpConf:   do.MustInvoke[*config.HTTP](i),
+		shutdown:   i.Shutdown,
 	}
 }

--- a/go-server/apps/shappar-api/cmd/server.go
+++ b/go-server/apps/shappar-api/cmd/server.go
@@ -13,10 +13,10 @@ import (
 
 func newServer(injected *injected) *http.Server {
 	r := chi.NewRouter()
-	// r.Use(injected.middleware.Recoverer)
+	r.Use(injected.middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 	r.Use(middleware.RealIP)
-	// r.Use(injected.middleware.CORS)
+	r.Use(injected.middleware.CORS)
 	r.Use(otelchi.Middleware("shappar-api", otelchi.WithChiRoutes(r),
 		otelchi.WithFilter(func(req *http.Request) bool {
 			if req.URL.Path == "/health" {
@@ -31,6 +31,10 @@ func newServer(injected *injected) *http.Server {
 	h := oas.HandlerWithOptions(injected.handler, oas.ChiServerOptions{
 		BaseURL:    "/v1",
 		BaseRouter: r,
+		Middlewares: []oas.MiddlewareFunc{
+			injected.middleware.AccessLogger,
+			injected.middleware.SetClient,
+		},
 	})
 
 	return &http.Server{

--- a/go-server/apps/shappar-api/gateway/middleware/access_log.go
+++ b/go-server/apps/shappar-api/gateway/middleware/access_log.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Hirochon/Shappar/core/util/log"
+	"github.com/Hirochon/Shappar/core/util/trace"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+type httpRequest struct {
+	RequestMethod string `json:"requestMethod"`
+	RequestUrl    string `json:"requestUrl"`
+	RequestSize   string `json:"requestSize"`
+	Status        int    `json:"status"`
+	ResponseSize  string `json:"responseSize"`
+	UserAgent     string `json:"userAgent"`
+	RemoteIP      string `json:"remoteIp"`
+	ServerIP      string `json:"serverIp"`
+	Referer       string `json:"referer"`
+	Latency       string `json:"latency"`
+}
+
+var logger = log.NewLogger(log.New(), log.LogTypeAccess)
+
+func (m *Middleware) AccessLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := trace.StartSpan(r.Context())
+		defer func() { trace.EndSpan(ctx, nil) }()
+
+		startTime := time.Now()
+
+		// リクエストボディ読み込み
+		reqBodyBuf, _ := io.ReadAll(r.Body)
+		// 一度読み切るとそれ以降読めなくなるため、再度詰め直す
+		r.Body = io.NopCloser(bytes.NewBuffer(reqBodyBuf))
+
+		// リクエストボディ読み込み
+		// レスポンスボディが取得できるようにラップする
+		lrw := middleware.NewWrapResponseWriter(w, 1)
+		resBodyBuf := &bytes.Buffer{}
+		lrw.Tee(resBodyBuf)
+
+		next.ServeHTTP(lrw, r)
+
+		route := chi.RouteContext(ctx).RoutePattern()
+		latency := fmt.Sprintf("%.9fs", time.Since(startTime).Seconds())
+
+		l := logger.With(
+			slog.Any("httpRequest", &httpRequest{
+				RequestMethod: r.Method,
+				RequestUrl:    r.RequestURI,
+				RequestSize:   fmt.Sprintf("%d", len(reqBodyBuf)),
+				ResponseSize:  fmt.Sprintf("%d", len(resBodyBuf.Bytes())),
+				UserAgent:     r.UserAgent(),
+				RemoteIP:      r.RemoteAddr,
+				Referer:       r.Referer(),
+				Status:        lrw.Status(),
+				Latency:       latency,
+			}),
+			slog.String("timestamp", startTime.Format("2006-01-02T15:04:05.999999999Z")),
+			slog.String("route", route),
+		)
+
+		switch {
+		case lrw.Status() <= 399:
+			l.Info(ctx, "")
+		case lrw.Status() >= 400 && lrw.Status() <= 499:
+			l.Warn(ctx, nil)
+		case lrw.Status() >= 500:
+			l.Error(ctx, nil)
+		}
+
+	})
+}

--- a/go-server/apps/shappar-api/gateway/middleware/access_log_test.go
+++ b/go-server/apps/shappar-api/gateway/middleware/access_log_test.go
@@ -1,0 +1,160 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/Hirochon/Shappar/core/util/config"
+	"github.com/Hirochon/Shappar/core/util/log"
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/go-chi/chi/v5"
+	cmiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/render"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+)
+
+type testLog struct {
+	Time           string            `json:"time"`
+	Severity       string            `json:"severity"`
+	SourceLocation sourceLocation    `json:"logging.googleapis.com/sourceLocation"`
+	Labels         map[string]string `json:"logging.googleapis.com/labels"`
+	HttpRequest    httpRequest       `json:"httpRequest"`
+	Route          string            `json:"route"`
+	TenantID       string            `json:"tenantId"`
+}
+
+type sourceLocation struct {
+	Function string `json:"function"`
+	File     string `json:"file"`
+	Message  string `json:"message"`
+}
+
+func extractStdout(t *testing.T, fnc func(w http.ResponseWriter, r *http.Request), rw http.ResponseWriter, rr *http.Request) *bytes.Buffer {
+	t.Helper()
+
+	orgStdout := os.Stdout
+	defer func() {
+		os.Stdout = orgStdout
+	}()
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	logger = log.NewLogger(log.New(), log.LogTypeAccess)
+
+	fnc(rw, rr)
+
+	w.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("failed to read buf: %v", err)
+	}
+	return &buf
+}
+
+func TestMiddleware_AccessLogger(t *testing.T) {
+	t.Setenv("LOG_FORMAT", string(config.LogFormatGCP))
+	config.Reload()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		want       testLog
+	}{
+		{
+			name:       "200 OK",
+			statusCode: http.StatusOK,
+			want: testLog{
+				Severity: "INFO",
+				Labels:   map[string]string{"logType": "accessLog"},
+				HttpRequest: httpRequest{
+					RequestMethod: "GET",
+					RequestUrl:    "http://localhost/test/1?p=1",
+					RequestSize:   "13",
+					ResponseSize:  "11",
+					RemoteIP:      "202.32.2.197",
+					UserAgent:     "user-agent",
+					Referer:       "http://sample.com/sample?p=2",
+					Status:        200,
+				},
+				Route: "/test/{testId}",
+			},
+		},
+		{
+			name:       "404 Not Found",
+			statusCode: http.StatusNotFound,
+			want: testLog{
+				Severity: "WARN",
+				Labels:   map[string]string{"logType": "accessLog"},
+				HttpRequest: httpRequest{
+					RequestMethod: "GET",
+					RequestUrl:    "http://localhost/test/1?p=1",
+					RequestSize:   "13",
+					ResponseSize:  "11",
+					RemoteIP:      "202.32.2.197",
+					UserAgent:     "user-agent",
+					Referer:       "http://sample.com/sample?p=2",
+					Status:        404,
+				},
+				Route: "/test/{testId}",
+			},
+		},
+		{
+			name:       "500 Internal Server Error",
+			statusCode: http.StatusInternalServerError,
+			want: testLog{
+				Severity: "ERROR",
+				Labels:   map[string]string{"logType": "accessLog"},
+				HttpRequest: httpRequest{
+					RequestMethod: "GET",
+					RequestUrl:    "http://localhost/test/1?p=1",
+					RequestSize:   "13",
+					ResponseSize:  "11",
+					RemoteIP:      "202.32.2.197",
+					UserAgent:     "user-agent",
+					Referer:       "http://sample.com/sample?p=2",
+					Status:        500,
+				},
+				Route: "/test/{testId}",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newMocks(t)
+
+			middleware := newTestMiddleware(m)
+			router := chi.NewRouter()
+			router.Use(cmiddleware.RealIP)
+			router.Get("/test/{testId}", func(w http.ResponseWriter, r *http.Request) {
+				middleware.AccessLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.statusCode)
+					io.WriteString(w, "response ok")
+				})).ServeHTTP(w, r)
+			})
+			req := bytes.NewBufferString("Hello!request")
+			r := httptest.NewRequest(http.MethodGet, "http://localhost/test/1?p=1", req)
+
+			// ヘッダーのセット
+			r.Header.Set("User-Agent", "user-agent")
+			r.Header.Set("Referer", "http://sample.com/sample?p=2")
+			r.Header.Set("X-Forwarded-For", "202.32.2.197, 34.107.251.243")
+
+			w := httptest.NewRecorder()
+			got := &testLog{}
+			assert.NoError(t, render.DecodeJSON(extractStdout(t, router.ServeHTTP, w, r), got))
+
+			if diff := cmp.Diff(tt.want, *got, cmpopts.IgnoreFields(*got, "Time", "HttpRequest", "SourceLocation")); diff != "" {
+				t.Errorf("unexpected result: %s", diff)
+			}
+			if diff := cmp.Diff(tt.want.HttpRequest, got.HttpRequest, cmpopts.IgnoreFields(got.HttpRequest, "ServerIP", "Latency")); diff != "" {
+				t.Errorf("unexpected httpRequest result: %s", diff)
+			}
+		})
+	}
+}

--- a/go-server/apps/shappar-api/gateway/middleware/client.go
+++ b/go-server/apps/shappar-api/gateway/middleware/client.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/Hirochon/Shappar/core/util/context"
+	"github.com/Hirochon/Shappar/core/util/trace"
+)
+
+func (m *Middleware) SetClient(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := trace.StartSpan(r.Context())
+		defer func() { trace.EndSpan(ctx, nil) }()
+
+		ctx = context.SetClient(ctx, &context.Client{
+			IP:        r.RemoteAddr,
+			UserAgent: r.UserAgent(),
+		})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/go-server/apps/shappar-api/gateway/middleware/client_test.go
+++ b/go-server/apps/shappar-api/gateway/middleware/client_test.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hirochon/Shappar/core/util/context"
+	"github.com/go-chi/chi/v5"
+	cmiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware_SetClient(t *testing.T) {
+	t.Parallel()
+
+	m := newMocks(t)
+	middleware := newTestMiddleware(m)
+	router := chi.NewRouter()
+	router.Use(cmiddleware.RealIP)
+	router.Get("/test", func(w http.ResponseWriter, r *http.Request) {
+		middleware.SetClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			client := context.GetClient(r.Context())
+			assert.Equal(t, &context.Client{
+				IP:        "111.222.111.222",
+				UserAgent: "ua",
+			}, client)
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(w, r)
+	})
+
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	r.Header.Set("X-Forwarded-For", "111.222.111.222")
+	r.Header.Set("User-Agent", "ua")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+}

--- a/go-server/apps/shappar-api/gateway/middleware/cors.go
+++ b/go-server/apps/shappar-api/gateway/middleware/cors.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/Hirochon/Shappar/core/util/config"
+	"github.com/go-chi/cors"
+)
+
+func (m *Middleware) CORS(next http.Handler) http.Handler {
+	if config.GetEnv() == config.EnvProduction {
+		return next
+	}
+	return cors.Handler(cors.Options{
+		AllowedOrigins: []string{"http://localhost:*"},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE"},
+		AllowedHeaders: []string{"Authorization", "Content-Type"},
+		MaxAge:         300,
+	})(next)
+}

--- a/go-server/apps/shappar-api/gateway/middleware/cors_test.go
+++ b/go-server/apps/shappar-api/gateway/middleware/cors_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Hirochon/Shappar/core/util/config"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware_CORS(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T)
+		origin       string
+		allowOrigin  string
+		allowMethods string
+		allowHeader  string
+		allowMaxAge  string
+		wantStatus   int
+	}{
+		{
+			name: "dev",
+			setup: func(t *testing.T) {
+				t.Setenv("ENV", "development")
+			},
+			origin:       "http://localhost:1234",
+			allowOrigin:  "http://localhost:1234",
+			allowMethods: "GET",
+			allowHeader:  "Authorization",
+			allowMaxAge:  "300",
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name: "staging",
+			setup: func(t *testing.T) {
+				t.Setenv("ENV", "staging")
+			},
+			origin:       "http://localhost:1234",
+			allowOrigin:  "http://localhost:1234",
+			allowMethods: "GET",
+			allowHeader:  "Authorization",
+			allowMaxAge:  "300",
+			wantStatus:   http.StatusOK,
+		},
+		{
+			name: "production",
+			setup: func(t *testing.T) {
+				t.Setenv("ENV", "production")
+			},
+			origin:       "http://localhost:1234",
+			allowOrigin:  "",
+			allowMethods: "",
+			allowHeader:  "",
+			allowMaxAge:  "",
+			wantStatus:   http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup(t)
+			require.NoError(t, config.Reload())
+			m := newMocks(t)
+			middleware := newTestMiddleware(m)
+			router := chi.NewRouter()
+			router.Use(middleware.CORS)
+			router.Options("/test", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			r := httptest.NewRequest(http.MethodOptions, "/test", nil)
+			r.Header.Set("Origin", tt.origin)
+			r.Header.Set("Access-Control-Request-Method", "GET")
+			r.Header.Set("Access-Control-Request-Headers", "Authorization")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			gotAllowOrigin := w.Result().Header.Get("Access-Control-Allow-Origin")
+			gotAllowMethods := w.Result().Header.Get("Access-Control-Allow-Methods")
+			gotAllowHeader := w.Result().Header.Get("Access-Control-Allow-Headers")
+			gotAllowMaxAge := w.Result().Header.Get("Access-Control-Max-Age")
+
+			assert.Equal(t, tt.allowOrigin, gotAllowOrigin)
+			assert.Equal(t, tt.allowMethods, gotAllowMethods)
+			assert.Equal(t, tt.allowHeader, gotAllowHeader)
+			assert.Equal(t, tt.allowMaxAge, gotAllowMaxAge)
+		})
+	}
+}

--- a/go-server/apps/shappar-api/gateway/middleware/di.go
+++ b/go-server/apps/shappar-api/gateway/middleware/di.go
@@ -1,0 +1,7 @@
+package middleware
+
+import "github.com/samber/do"
+
+func Inject(i *do.Injector) {
+	do.Provide(i, New)
+}

--- a/go-server/apps/shappar-api/gateway/middleware/middleware.go
+++ b/go-server/apps/shappar-api/gateway/middleware/middleware.go
@@ -1,0 +1,11 @@
+package middleware
+
+import (
+	"github.com/samber/do"
+)
+
+type Middleware struct{}
+
+func New(i *do.Injector) (*Middleware, error) {
+	return &Middleware{}, nil
+}

--- a/go-server/apps/shappar-api/gateway/middleware/middleware_test.go
+++ b/go-server/apps/shappar-api/gateway/middleware/middleware_test.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"testing"
+)
+
+type mocks struct{}
+
+func newMocks(t *testing.T) *mocks {
+	return &mocks{}
+}
+
+func newTestMiddleware(m *mocks) *Middleware {
+	return &Middleware{}
+}

--- a/go-server/apps/shappar-api/gateway/middleware/recoverer.go
+++ b/go-server/apps/shappar-api/gateway/middleware/recoverer.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"regexp"
+
+	"github.com/Hirochon/Shappar/core/util/code"
+	"github.com/Hirochon/Shappar/core/util/log"
+)
+
+var re = regexp.MustCompile(`/users/([^/]+)`)
+
+func (m *Middleware) Recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rvr := recover(); rvr != nil {
+				if rvr == http.ErrAbortHandler {
+					// abortエラーは接続を中止しクライアントにエラーを伝えるため、
+					// recoverはしない
+					// https://github.com/go-chi/chi/pull/624
+					panic(rvr)
+				}
+
+				log.Error(r.Context(), code.NewError(code.Internal, "panic has occurred"),
+					slog.Any("recoverResponse", rvr),
+					slog.String("path", r.RequestURI),
+					slog.String("userId", getUserID(r.RequestURI)),
+				)
+
+				if r.Header.Get("Connection") != "Upgrade" {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func getUserID(path string) string {
+	matches := re.FindStringSubmatch(path)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[1]
+}

--- a/go-server/apps/shappar-api/gateway/middleware/recoverer_test.go
+++ b/go-server/apps/shappar-api/gateway/middleware/recoverer_test.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware_Recoverer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		panicErr   error
+		wantStatus int
+	}{
+		{
+			name:       "success",
+			panicErr:   assert.AnError,
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newMocks(t)
+			middleware := newTestMiddleware(m)
+
+			router := chi.NewRouter()
+			router.Use(middleware.Recoverer)
+			router.Get("/test/users/user-id", func(w http.ResponseWriter, r *http.Request) {
+				panic(http.ErrBodyNotAllowed)
+			})
+
+			r := httptest.NewRequest(http.MethodGet, "/test/users/user-id", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, r)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}
+
+func Test_getUserID(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "no users path",
+			path: "/test",
+			want: "",
+		},
+		{
+			name: "success",
+			path: "/test/users/user-id",
+			want: "user-id",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := getUserID(tt.path)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go-server/core/util/code/error_test.go
+++ b/go-server/core/util/code/error_test.go
@@ -132,14 +132,14 @@ func TestUnwrapError(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name:    "not amphora error",
+			name:    "not shappar error",
 			err:     errors.New("error"),
 			hasErr:  true,
 			wantErr: "error",
 		},
 		{
-			name:    "amphora error",
-			err:     WrapError(errors.New("original error"), Unknown, "amphora error"),
+			name:    "shappar error",
+			err:     WrapError(errors.New("original error"), Unknown, "shappar error"),
 			hasErr:  true,
 			wantErr: "original error",
 		},
@@ -171,14 +171,14 @@ func TestGetCode(t *testing.T) {
 			want: OK,
 		},
 		{
-			name: "amphora error",
+			name: "shappar error",
 			err: &ShapparError{
 				code: Internal,
 			},
 			want: Internal,
 		},
 		{
-			name: "not amphora error",
+			name: "not shappar error",
 			err:  errors.New("error"),
 			want: Unknown,
 		},
@@ -206,14 +206,14 @@ func TestGetMessage(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "amphora error",
+			name: "shappar error",
 			err: &ShapparError{
 				message: "m",
 			},
 			want: "m",
 		},
 		{
-			name: "not amphora error",
+			name: "not shappar error",
 			err:  errors.New("error"),
 			want: "error",
 		},
@@ -241,12 +241,12 @@ func TestGetStack(t *testing.T) {
 			hasStack: false,
 		},
 		{
-			name:     "amphora error",
+			name:     "shappar error",
 			err:      NewError(Internal, "error"),
 			hasStack: true,
 		},
 		{
-			name:     "not amphora error",
+			name:     "not shappar error",
 			err:      errors.New("error"),
 			hasStack: false,
 		},
@@ -274,17 +274,17 @@ func TestGetAttrs(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "not amphora error",
+			name: "not shappar error",
 			err:  errors.New("error"),
 			want: nil,
 		},
 		{
-			name: "new amphora error without attributes",
+			name: "new shappar error without attributes",
 			err:  NewError(Internal, "error"),
 			want: nil,
 		},
 		{
-			name: "new amphora error with attributes",
+			name: "new shappar error with attributes",
 			err: NewError(Internal, "error",
 				WithAttr("key1", "value1"),
 				WithAttr("key2", "value2"), // 上書きされる
@@ -299,7 +299,7 @@ func TestGetAttrs(t *testing.T) {
 			},
 		},
 		{
-			name: "wrap not amphora error with attributes",
+			name: "wrap not shappar error with attributes",
 			err: func() error {
 				e := errors.New("error")
 				return WrapError(e, Internal, "error",
@@ -314,7 +314,7 @@ func TestGetAttrs(t *testing.T) {
 			},
 		},
 		{
-			name: "wrap amphora error with attributes",
+			name: "wrap shappar error with attributes",
 			err: func() error {
 				e := NewError(Internal, "e1",
 					WithAttr("key1", "value1"),

--- a/go-server/core/util/context/client.go
+++ b/go-server/core/util/context/client.go
@@ -1,0 +1,19 @@
+package context
+
+import "context"
+
+type Client struct {
+	IP        string
+	UserAgent string
+}
+
+type clientKey struct{}
+
+func SetClient(ctx context.Context, client *Client) context.Context {
+	return context.WithValue(ctx, clientKey{}, client)
+}
+
+func GetClient(ctx context.Context) *Client {
+	params, _ := ctx.Value(clientKey{}).(*Client)
+	return params
+}

--- a/go-server/core/util/context/client_test.go
+++ b/go-server/core/util/context/client_test.go
@@ -1,0 +1,27 @@
+package context
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// クライアント情報が設定されていないこと
+	got := GetClient(ctx)
+	assert.Nil(t, got)
+
+	// クライアント情報を設定できること
+	cli := &Client{
+		IP:        "ip",
+		UserAgent: "ua",
+	}
+	ctx = SetClient(ctx, cli)
+	got = GetClient(ctx)
+	assert.Equal(t, cli, got)
+}

--- a/go-server/core/util/trace/trace.go
+++ b/go-server/core/util/trace/trace.go
@@ -1,0 +1,42 @@
+package trace
+
+import (
+	"context"
+	"runtime"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	ottrace "go.opentelemetry.io/otel/trace"
+)
+
+const otelTracerName = "shappar"
+
+func StartSpan(ctx context.Context) context.Context {
+	ctx, _ = otel.GetTracerProvider().Tracer(otelTracerName).Start(ctx, funcName())
+	return ctx
+}
+
+func EndSpan(ctx context.Context, err error) {
+	span := ottrace.SpanFromContext(ctx)
+	if err != nil {
+		span.RecordError(err)
+	}
+	span.End()
+}
+
+func funcName() string {
+	// 呼び出し元情報を取得
+	pc, _, _, ok := runtime.Caller(2)
+	if !ok {
+		return ""
+	}
+
+	// 関数名を取得
+	fn := runtime.FuncForPC(pc)
+
+	trimPrefix := "github.com/Hirochon/Shappar/"
+	if strings.HasPrefix(fn.Name(), trimPrefix) {
+		return strings.TrimPrefix(fn.Name(), trimPrefix)
+	}
+	return fn.Name()
+}

--- a/go-server/go.mod
+++ b/go-server/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/oapi-codegen/runtime v1.3.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/sdk/metric v1.42.0
@@ -36,7 +37,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/oapi-codegen/oapi-codegen/v2 v2.6.0 // indirect
-	github.com/oapi-codegen/runtime v1.3.1 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
@@ -72,6 +72,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.31.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/go-chi/cors v1.2.2
 	github.com/go-chi/render v1.0.3
 	github.com/google/go-cmp v0.7.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go-server/go.sum
+++ b/go-server/go.sum
@@ -61,11 +61,14 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getkin/kin-openapi v0.133.0 h1:pJdmNohVIJ97r4AUFtEXRXwESr8b0bD721u/Tz6k8PQ=
 github.com/getkin/kin-openapi v0.133.0/go.mod h1:boAciF6cXk5FhPqe/NQeBTeenbjqU4LhWBf09ILVvWE=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
+github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
 github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
@@ -80,6 +83,8 @@ github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kO
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=
 github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -129,11 +134,10 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oapi-codegen/oapi-codegen/v2 v2.6.0 h1:4i+F2cvwBFZeplxCssNdLy3MhNzUD87mI3HnayHZkAU=
 github.com/oapi-codegen/oapi-codegen/v2 v2.6.0/go.mod h1:eWHeJSohQJIINJZzzQriVynfGsnlQVh0UkN2UYYcw4Q=
-github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
-github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oapi-codegen/runtime v1.3.1 h1:RgDY6J4OGQLbRXhG/Xpt3vSVqYpHQS7hN4m85+5xB9g=
 github.com/oapi-codegen/runtime v1.3.1/go.mod h1:kOdeacKy7t40Rclb1je37ZLFboFxh+YLy0zaPCMibPY=
 github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
@@ -143,12 +147,14 @@ github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
@@ -165,6 +171,7 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/samber/do v1.6.0 h1:Jy/N++BXINDB6lAx5wBlbpHlUdl0FKpLWgGEV9YWqaU=
 github.com/samber/do v1.6.0/go.mod h1:DWqBvumy8dyb2vEnYZE7D7zaVEB64J45B0NjTlY/M4k=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/speakeasy-api/jsonpath v0.6.0 h1:IhtFOV9EbXplhyRqsVhHoBmmYjblIRh5D1/g8DHMXJ8=
 github.com/speakeasy-api/jsonpath v0.6.0/go.mod h1:ymb2iSkyOycmzKwbEAYPJV/yi2rSmvBCLZJcyD+VVWw=
@@ -179,6 +186,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
+github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
@@ -292,6 +301,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## 概要

`shappar-api` に共通 middleware を追加し、サーバー起動時に panic recovery・CORS・access log・client context を組み込めるようにしました。あわせて tracing ユーティリティと関連テストを整備しています。

## 変更点

- `Middleware` の DI を追加し、`cmd/server.go` で `Recoverer` / `CORS` / `AccessLogger` / `SetClient` を適用
- access log middleware を追加し、ステータス・レスポンスサイズ・User-Agent・route・latency を記録
- request context にクライアント IP と User-Agent を保持する middleware を追加
- panic 発生時に 500 応答とログ出力を行う recoverer middleware を追加
- middleware から利用する tracing ユーティリティを追加
- middleware / context / error code のテストを追加・更新

## 背景 / 目的

HTTP レイヤーの横断関心事を先に共通化しておくことで、今後 handler や usecase を実装するときにルーティング側へ毎回個別対応を入れずに済むようにするためです。API の観測性と障害時の最低限の保護もこの段階で揃えます。

## 影響範囲

- 対象画面: なし（backend only）
- 対象ユーザー: `shappar-api` を利用する全ユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: なし
- After: なし

### 操作動画

- なし

### UI変更なし

- [x] UI変更なし

## 確認項目

- [ ] ローカルで対象画面を確認
- [ ] 主要導線を一通り操作
- [x] `react-front` に変更がないため `build` 実行不要
- [x] `cd go-server && go test ./...`

## 関連issue

- なし

## 補足

- reviewer向け確認手順: `cd go-server && go test ./...` を実行し、必要に応じて `go-server/apps/shappar-api/cmd/server.go` の middleware 適用順を確認してください
- 必要な環境変数やログイン方法: 追加なし
