### PR TITLE
feat: add poll detail voting flow

### DIFF
--- a/frontend/src/hooks/usePollDetail.ts
+++ b/frontend/src/hooks/usePollDetail.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { Post } from '@/types/api';
+
+export function pollDetailQueryKey(postId: string) {
+  return ['poll-detail', postId] as const;
+}
+
+export function usePollDetail(postId: string) {
+  return useQuery({
+    queryKey: pollDetailQueryKey(postId),
+    queryFn: () => apiClient.get<Post>(`/api/v1/posts/${postId}`),
+    enabled: Boolean(postId),
+    refetchInterval: 10_000,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/frontend/src/hooks/useVote.ts
+++ b/frontend/src/hooks/useVote.ts
@@ -1,0 +1,83 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import { pollDetailQueryKey } from '@/hooks/usePollDetail';
+import type { Post, VotePayload, VoteResponse } from '@/types/api';
+
+interface VoteVariables {
+  selectNum: number;
+}
+
+function getNormalizedVotes(votes: number | undefined) {
+  return Math.max(votes ?? 0, 0);
+}
+
+function createOptimisticPost(post: Post, selectNum: number): Post {
+  return {
+    ...post,
+    voted: true,
+    selected_num: selectNum,
+    total: post.total + 1,
+    options: post.options.map((option) => ({
+      ...option,
+      votes:
+        getNormalizedVotes(option.votes) + (option.select_num === selectNum ? 1 : 0),
+    })),
+  };
+}
+
+function mergeVoteResponse(post: Post, response: VoteResponse) {
+  const votesByOption = new Map(
+    response.options.map((option) => [option.select_num, option.votes]),
+  );
+
+  return {
+    ...post,
+    voted: true,
+    selected_num: response.selected_num,
+    total: response.total,
+    options: post.options.map((option) => ({
+      ...option,
+      votes: votesByOption.get(option.select_num) ?? getNormalizedVotes(option.votes),
+    })),
+  };
+}
+
+export function useVote(postId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = pollDetailQueryKey(postId);
+
+  return useMutation({
+    mutationFn: ({ selectNum }: VoteVariables) =>
+      apiClient.post<VoteResponse>(`/api/v1/posts/${postId}/polls`, {
+        option: {
+          select_num: selectNum,
+        },
+      } satisfies VotePayload),
+    onMutate: async ({ selectNum }) => {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousPost = queryClient.getQueryData<Post>(queryKey);
+
+      if (previousPost) {
+        queryClient.setQueryData(queryKey, createOptimisticPost(previousPost, selectNum));
+      }
+
+      return { previousPost };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousPost) {
+        queryClient.setQueryData(queryKey, context.previousPost);
+      }
+    },
+    onSuccess: (response) => {
+      const currentPost = queryClient.getQueryData<Post>(queryKey);
+
+      if (currentPost) {
+        queryClient.setQueryData(queryKey, mergeVoteResponse(currentPost, response));
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey });
+    },
+  });
+}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,8 +1,14 @@
 import { HttpResponse, http } from 'msw';
+import {
+  MOCK_AUTH_USER_ID,
+  deleteMockPollPost,
+  getMockPollPost,
+  voteMockPollPost,
+} from '@/mocks/poll-data';
 
 const mockAuthUser = {
   unique_id: 'unique-user-123',
-  user_id: 'user-123',
+  user_id: MOCK_AUTH_USER_ID,
   name: 'Shappar User',
   introduction: 'I love taking pictures with friends.',
   iconimage: 'https://example.com/icon.png',
@@ -21,5 +27,55 @@ export const handlers = [
   }),
   http.get('/api/v1/health', () => {
     return HttpResponse.json({ status: 'ok' });
+  }),
+  http.get('http://localhost:8040/api/v1/posts/:id', ({ params }) => {
+    const post = getMockPollPost(String(params.id));
+
+    if (!post) {
+      return HttpResponse.json(
+        { detail: '存在しない投稿IDです。' },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(post);
+  }),
+  http.post('http://localhost:8040/api/v1/posts/:id/polls', async ({ params, request }) => {
+    const body = (await request.json()) as {
+      option?: {
+        select_num?: number;
+      };
+    };
+    const selectNum = body.option?.select_num;
+
+    if (typeof selectNum !== 'number') {
+      return HttpResponse.json(
+        { detail: '選択肢が指定されていません。' },
+        { status: 400 },
+      );
+    }
+
+    const result = voteMockPollPost(String(params.id), selectNum);
+
+    if (result.status !== 201) {
+      return HttpResponse.json(
+        { detail: result.message ?? '投票に失敗しました。' },
+        { status: result.status },
+      );
+    }
+
+    return HttpResponse.json(result.response, { status: 201 });
+  }),
+  http.delete('http://localhost:8040/api/v1/posts/:id', ({ params }) => {
+    const result = deleteMockPollPost(String(params.id));
+
+    if (result.status === 204) {
+      return new HttpResponse(null, { status: 204 });
+    }
+
+    return HttpResponse.json(
+      { detail: result.message ?? '投稿を削除できませんでした。' },
+      { status: result.status },
+    );
   }),
 ];

--- a/frontend/src/mocks/poll-data.ts
+++ b/frontend/src/mocks/poll-data.ts
@@ -1,0 +1,148 @@
+import type { Post, VoteResponse } from '@/types/api';
+
+export const MOCK_AUTH_USER_ID = 'user-123';
+
+const initialPollPosts: Record<string, Post> = {
+  'post-unvoted': {
+    post_id: 'post-unvoted',
+    user_id: 'creator-001',
+    iconimage: 'https://example.com/creator-001.png',
+    question: '次にみんなで撮りに行くならどこ？',
+    voted: false,
+    options: [
+      { select_num: 0, answer: '海辺', votes: -1 },
+      { select_num: 1, answer: '駅前スナップ', votes: -1 },
+      { select_num: 2, answer: '夜景スポット', votes: -1 },
+    ],
+    created_at: '2026-04-01T12:00:00.000Z',
+    selected_num: -1,
+    total: 0,
+  },
+  'post-voted': {
+    post_id: 'post-voted',
+    user_id: 'creator-002',
+    iconimage: 'https://example.com/creator-002.png',
+    question: '旅行先で撮りたいテーマは？',
+    voted: true,
+    options: [
+      { select_num: 0, answer: '朝焼け', votes: 2 },
+      { select_num: 1, answer: '街のディテール', votes: 4 },
+      { select_num: 2, answer: 'ポートレート', votes: 2 },
+    ],
+    created_at: '2026-03-30T09:30:00.000Z',
+    selected_num: 1,
+    total: 8,
+  },
+  'post-owned': {
+    post_id: 'post-owned',
+    user_id: MOCK_AUTH_USER_ID,
+    iconimage: 'https://example.com/user-123.png',
+    question: '次のオフ会で最初に撮る 1 枚は？',
+    voted: true,
+    options: [
+      { select_num: 0, answer: '集合写真', votes: 3 },
+      { select_num: 1, answer: '料理', votes: 5 },
+      { select_num: 2, answer: '会場の雰囲気', votes: 2 },
+    ],
+    created_at: '2026-03-28T18:45:00.000Z',
+    selected_num: -1,
+    total: 10,
+  },
+};
+
+let pollPosts = structuredClone(initialPollPosts);
+
+function clonePost(post: Post) {
+  return structuredClone(post);
+}
+
+function getNormalizedVotes(votes: number | undefined) {
+  return Math.max(votes ?? 0, 0);
+}
+
+export function resetMockPollPosts() {
+  pollPosts = structuredClone(initialPollPosts);
+}
+
+export function getMockPollPost(postId: string) {
+  const post = pollPosts[postId];
+
+  return post ? clonePost(post) : null;
+}
+
+export function voteMockPollPost(
+  postId: string,
+  selectNum: number,
+  userId = MOCK_AUTH_USER_ID,
+) {
+  const post = pollPosts[postId];
+
+  if (!post) {
+    return { status: 404 as const };
+  }
+
+  if (post.user_id === userId) {
+    return {
+      status: 400 as const,
+      message: '投稿した本人は投票できません。',
+    };
+  }
+
+  if (post.voted) {
+    return {
+      status: 409 as const,
+      message: 'この投稿にはすでに投票済みです。',
+    };
+  }
+
+  const targetOption = post.options.find((option) => option.select_num === selectNum);
+
+  if (!targetOption) {
+    return {
+      status: 400 as const,
+      message: '存在しない選択肢です。',
+    };
+  }
+
+  post.voted = true;
+  post.selected_num = selectNum;
+  post.total += 1;
+  post.options = post.options.map((option) => ({
+    ...option,
+    votes:
+      getNormalizedVotes(option.votes) + (option.select_num === selectNum ? 1 : 0),
+  }));
+
+  const response: VoteResponse = {
+    options: post.options.map((option) => ({
+      select_num: option.select_num,
+      votes: getNormalizedVotes(option.votes),
+    })),
+    selected_num: selectNum,
+    total: post.total,
+  };
+
+  return {
+    status: 201 as const,
+    response,
+  };
+}
+
+export function deleteMockPollPost(postId: string, userId = MOCK_AUTH_USER_ID) {
+  const post = pollPosts[postId];
+
+  if (!post) {
+    return { status: 404 as const };
+  }
+
+  if (post.user_id !== userId) {
+    return {
+      status: 403 as const,
+      message: 'この投稿を削除する権限がありません。',
+    };
+  }
+
+  delete pollPosts[postId];
+
+  return { status: 204 as const };
+}

--- a/frontend/src/pages/PollDetailPage.tsx
+++ b/frontend/src/pages/PollDetailPage.tsx
@@ -1,0 +1,293 @@
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ErrorDisplay } from '@/components/error-display';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { usePollDetail } from '@/hooks/usePollDetail';
+import { useVote } from '@/hooks/useVote';
+import { apiClient } from '@/lib/api-client';
+import { getApiErrorMessage } from '@/hooks/use-api-error-handler';
+import { useAuthStore } from '@/stores/auth-store';
+import type { PostOption } from '@/types/api';
+
+function formatCreatedAt(value: string) {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value));
+}
+
+function getNormalizedVotes(votes: number | undefined) {
+  return Math.max(votes ?? 0, 0);
+}
+
+function getPercentage(option: PostOption, total: number) {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Math.round((getNormalizedVotes(option.votes) / total) * 100);
+}
+
+function LoadingState() {
+  return (
+    <main className="flex min-h-[60vh] items-center justify-center px-4 py-10">
+      <div
+        aria-live="polite"
+        className="space-y-4 text-center"
+        role="status"
+      >
+        <div className="mx-auto size-12 animate-spin rounded-full border-4 border-slate-200 border-t-sky-600" />
+        <div className="space-y-1">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+            Poll Detail
+          </p>
+          <p className="text-base text-slate-600">
+            投票詳細を読み込んでいます...
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export function PollDetailPage() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+  const authUser = useAuthStore((state) => state.authUser);
+  const {
+    data: post,
+    error: pollDetailError,
+    isError: isPollDetailError,
+    isLoading,
+    refetch,
+  } = usePollDetail(id);
+  const voteMutation = useVote(id);
+  const deleteMutation = useMutation({
+    mutationFn: () => apiClient.delete(`/api/v1/posts/${id}`),
+    onSuccess: () => {
+      void navigate('/', { replace: true });
+    },
+  });
+
+  const errorMessage = useMemo(() => {
+    if (voteMutation.isError) {
+      return getApiErrorMessage(voteMutation.error);
+    }
+
+    if (deleteMutation.isError) {
+      return getApiErrorMessage(deleteMutation.error);
+    }
+
+    if (isPollDetailError) {
+      return getApiErrorMessage(pollDetailError);
+    }
+
+    return null;
+  }, [
+    deleteMutation.error,
+    deleteMutation.isError,
+    isPollDetailError,
+    pollDetailError,
+    voteMutation.error,
+    voteMutation.isError,
+  ]);
+
+  if (!id) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <ErrorDisplay
+          message="投稿 ID が見つかりませんでした。"
+          onRetry={() => {
+            void navigate('/');
+          }}
+        />
+      </main>
+    );
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!post) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <ErrorDisplay
+          message={getApiErrorMessage(pollDetailError)}
+          onRetry={() => {
+            void refetch();
+          }}
+        />
+      </main>
+    );
+  }
+
+  const isOwner = authUser?.user_id === post.user_id;
+  const showResults = post.voted;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-6">
+      <div className="space-y-6">
+        <Card className="overflow-hidden border-slate-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+          <div className="bg-[linear-gradient(135deg,_rgba(14,165,233,0.15),_rgba(226,232,240,0.8))] p-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-3">
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-700">
+                  Poll Detail
+                </p>
+                <div className="space-y-2">
+                  <h1 className="text-3xl font-semibold leading-tight text-slate-950">
+                    {post.question}
+                  </h1>
+                  <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                    {showResults
+                      ? '現在の得票結果を表示しています。'
+                      : '気になる選択肢を 1 つ選んで投票してください。'}
+                  </p>
+                </div>
+              </div>
+              {isOwner ? (
+                <Button
+                  className="gap-2 self-start"
+                  disabled={deleteMutation.isPending}
+                  onClick={() => {
+                    deleteMutation.mutate();
+                  }}
+                  type="button"
+                  variant="outline"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="size-4"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M3 6h18M8 6V4h8v2m-7 3v8m6-8v8M6 6l1 14h10l1-14"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="1.8"
+                    />
+                  </svg>
+                  {deleteMutation.isPending ? '削除中...' : '削除'}
+                </Button>
+              ) : null}
+            </div>
+          </div>
+          <CardContent className="space-y-6 p-6">
+            <dl className="grid gap-3 rounded-2xl bg-slate-50 p-4 sm:grid-cols-3">
+              <div className="space-y-1">
+                <dt className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  作成者
+                </dt>
+                <dd className="text-sm font-medium text-slate-900">
+                  @{post.user_id}
+                </dd>
+              </div>
+              <div className="space-y-1">
+                <dt className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  投票数
+                </dt>
+                <dd className="text-sm font-medium text-slate-900">
+                  {post.total}票
+                </dd>
+              </div>
+              <div className="space-y-1">
+                <dt className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  作成日時
+                </dt>
+                <dd className="text-sm font-medium text-slate-900">
+                  <time dateTime={post.created_at}>
+                    {formatCreatedAt(post.created_at)}
+                  </time>
+                </dd>
+              </div>
+            </dl>
+
+            {errorMessage ? (
+              <ErrorDisplay
+                message={errorMessage}
+                onRetry={() => {
+                  if (isPollDetailError) {
+                    void refetch();
+                  }
+                }}
+              />
+            ) : null}
+
+            {showResults ? (
+              <section aria-label="投票結果" className="space-y-4">
+                {post.options.map((option) => {
+                  const votes = getNormalizedVotes(option.votes);
+                  const percentage = getPercentage(option, post.total);
+                  const isSelected = post.selected_num === option.select_num;
+
+                  return (
+                    <article
+                      className="space-y-2 rounded-2xl border border-slate-200 p-4"
+                      key={option.select_num}
+                    >
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="space-y-1">
+                          <p className="text-base font-semibold text-slate-950">
+                            {option.answer}
+                          </p>
+                          {isSelected ? (
+                            <p className="text-xs font-medium text-sky-700">
+                              あなたの投票
+                            </p>
+                          ) : null}
+                        </div>
+                        <p className="text-sm font-medium text-slate-600">
+                          {votes}票 / {percentage}%
+                        </p>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        className="h-3 overflow-hidden rounded-full bg-slate-200"
+                      >
+                        <div
+                          className="h-full rounded-full bg-[linear-gradient(90deg,_#0ea5e9,_#38bdf8)] transition-[width] duration-300"
+                          data-testid={`poll-result-bar-${option.select_num}`}
+                          style={{ width: `${percentage}%` }}
+                        />
+                      </div>
+                    </article>
+                  );
+                })}
+              </section>
+            ) : (
+              <section aria-label="投票選択肢" className="space-y-3">
+                {post.options.map((option) => (
+                  <Button
+                    className="flex h-auto w-full items-center justify-between rounded-2xl border border-slate-200 bg-white px-5 py-4 text-left text-base font-semibold text-slate-950 shadow-sm transition-transform hover:-translate-y-0.5 hover:bg-slate-50"
+                    disabled={voteMutation.isPending}
+                    key={option.select_num}
+                    onClick={() => {
+                      voteMutation.mutate({
+                        selectNum: option.select_num,
+                      });
+                    }}
+                    type="button"
+                    variant="ghost"
+                  >
+                    <span>{option.answer}</span>
+                    <span className="text-sm font-medium text-slate-400">
+                      投票する
+                    </span>
+                  </Button>
+                ))}
+              </section>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/__tests__/poll-detail-page.test.tsx
+++ b/frontend/src/pages/__tests__/poll-detail-page.test.tsx
@@ -178,7 +178,7 @@ describe('PollDetailPage', () => {
     expect(screen.queryByText('投票する')).not.toBeInTheDocument();
   });
 
-  it('shows the loading state while the detail query is pending', async () => {
+  it('shows the loading state while the detail query is pending', () => {
     server.use(
       http.get(`${API_BASE_URL}/api/v1/posts/post-unvoted`, async () => {
         await delay(200);

--- a/frontend/src/pages/__tests__/poll-detail-page.test.tsx
+++ b/frontend/src/pages/__tests__/poll-detail-page.test.tsx
@@ -1,0 +1,221 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, delay, http } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return {
+    auth: mockAuth,
+  };
+});
+
+import { createQueryClient } from '@/lib/query-client';
+import {
+  MOCK_AUTH_USER_ID,
+  getMockPollPost,
+  resetMockPollPosts,
+  voteMockPollPost,
+} from '@/mocks/poll-data';
+import { PollDetailPage } from '@/pages/PollDetailPage';
+import { useAuthStore } from '@/stores/auth-store';
+import { server } from '@/test/mocks/server';
+import { render, screen, userEvent, waitFor, within } from '@/test/test-utils';
+
+const API_BASE_URL = 'http://localhost:8040';
+
+function createAuthUser(overrides: Partial<ReturnType<typeof useAuthStore.getState>['authUser']> = {}) {
+  return {
+    unique_id: 'unique-user-123',
+    user_id: MOCK_AUTH_USER_ID,
+    name: 'Shappar User',
+    introduction: '写真仲間と投票を楽しむユーザー',
+    iconimage: 'https://example.com/icon.png',
+    homeimage: 'https://example.com/home.png',
+    ...overrides,
+  };
+}
+
+function renderPollDetailPage(postId: string) {
+  const queryClient = createQueryClient();
+  const defaultOptions = queryClient.getDefaultOptions();
+
+  queryClient.setDefaultOptions({
+    queries: {
+      ...defaultOptions.queries,
+      retry: false,
+    },
+    mutations: {
+      ...defaultOptions.mutations,
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/polls/${postId}`]}>
+        <Routes>
+          <Route element={<PollDetailPage />} path="/polls/:id" />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('PollDetailPage', () => {
+  beforeEach(() => {
+    resetMockPollPosts();
+    useAuthStore.setState({
+      firebaseUser: null,
+      authUser: createAuthUser(),
+      isAuthenticated: true,
+      isLoading: false,
+    });
+  });
+
+  it('shows the question and the list of choices', async () => {
+    renderPollDetailPage('post-unvoted');
+
+    expect(
+      await screen.findByRole('heading', {
+        name: '次にみんなで撮りに行くならどこ？',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: /海辺.*投票する/u }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /駅前スナップ.*投票する/u }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /夜景スポット.*投票する/u }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders clickable option buttons before the user has voted', async () => {
+    renderPollDetailPage('post-unvoted');
+
+    const optionButton = await screen.findByRole('button', {
+      name: /海辺.*投票する/u,
+    });
+
+    expect(optionButton).toBeEnabled();
+    expect(screen.getByLabelText('投票選択肢')).toBeInTheDocument();
+  });
+
+  it('calls the vote API when an option is clicked', async () => {
+    let requestBody: unknown;
+
+    server.use(
+      http.post(`${API_BASE_URL}/api/v1/posts/:id/polls`, async ({ params, request }) => {
+        requestBody = await request.json();
+        const response = voteMockPollPost(String(params.id), 1);
+
+        return HttpResponse.json(response.response, { status: 201 });
+      }),
+    );
+
+    renderPollDetailPage('post-unvoted');
+
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /駅前スナップ.*投票する/u,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(requestBody).toEqual({
+        option: {
+          select_num: 1,
+        },
+      });
+    });
+  });
+
+  it('shows result bars after voting', async () => {
+    renderPollDetailPage('post-unvoted');
+
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /海辺.*投票する/u,
+      }),
+    );
+
+    const resultsSection = await screen.findByLabelText('投票結果');
+    const firstResult = within(resultsSection).getByText('海辺').closest('article');
+
+    expect(resultsSection).toBeInTheDocument();
+    expect(firstResult).not.toBeNull();
+    expect(screen.getByTestId('poll-result-bar-0')).toHaveStyle({ width: '100%' });
+  });
+
+  it('shows the vote count and percentage after voting', async () => {
+    renderPollDetailPage('post-voted');
+
+    expect(await screen.findByText('4票 / 50%')).toBeInTheDocument();
+    expect(screen.getAllByText('2票 / 25%')).toHaveLength(2);
+    expect(screen.getByText('投票数')).toBeInTheDocument();
+    expect(screen.getByText('8票')).toBeInTheDocument();
+  });
+
+  it('shows results immediately for users who already voted', async () => {
+    renderPollDetailPage('post-voted');
+
+    expect(await screen.findByLabelText('投票結果')).toBeInTheDocument();
+    expect(screen.queryByLabelText('投票選択肢')).not.toBeInTheDocument();
+  });
+
+  it('does not allow a second vote once the user has already voted', async () => {
+    renderPollDetailPage('post-voted');
+
+    await screen.findByLabelText('投票結果');
+
+    expect(
+      screen.queryByRole('button', { name: /朝焼け.*投票する/u }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('投票する')).not.toBeInTheDocument();
+  });
+
+  it('shows the loading state while the detail query is pending', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/posts/post-unvoted`, async () => {
+        await delay(200);
+
+        return HttpResponse.json(getMockPollPost('post-unvoted'));
+      }),
+    );
+
+    renderPollDetailPage('post-unvoted');
+
+    expect(screen.getByText('投票詳細を読み込んでいます...')).toBeInTheDocument();
+  });
+
+  it('shows the error state when the detail query fails', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/posts/post-missing`, () => {
+        return HttpResponse.json(
+          { detail: '存在しない投稿IDです。' },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderPollDetailPage('post-missing');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      '見つかりませんでした',
+    );
+  });
+
+  it('shows the delete button only for the author', async () => {
+    renderPollDetailPage('post-owned');
+
+    expect(
+      await screen.findByRole('button', {
+        name: '削除',
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -4,6 +4,7 @@ import { ProtectedRoute, PublicRoute } from '@/components/auth-guard';
 import { HomePage } from '@/pages/home-page';
 import { LoginPage } from '@/pages/login-page';
 import { NotFoundPage } from '@/pages/not-found-page';
+import { PollDetailPage } from '@/pages/PollDetailPage';
 
 export const appRoutes: RouteObject[] = [
   {
@@ -26,6 +27,10 @@ export const appRoutes: RouteObject[] = [
           {
             index: true,
             element: <HomePage />,
+          },
+          {
+            path: 'polls/:id',
+            element: <PollDetailPage />,
           },
         ],
       },

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,8 +1,14 @@
 import { HttpResponse, http } from 'msw';
+import {
+  MOCK_AUTH_USER_ID,
+  deleteMockPollPost,
+  getMockPollPost,
+  voteMockPollPost,
+} from '@/mocks/poll-data';
 
 const mockAuthUser = {
   unique_id: 'unique-user-123',
-  user_id: 'user-123',
+  user_id: MOCK_AUTH_USER_ID,
   name: 'Shappar User',
   introduction: 'I love taking pictures with friends.',
   iconimage: 'https://example.com/icon.png',
@@ -21,5 +27,55 @@ export const handlers = [
   }),
   http.get('/api/health', () => {
     return HttpResponse.json({ status: 'ok' });
+  }),
+  http.get('http://localhost:8040/api/v1/posts/:id', ({ params }) => {
+    const post = getMockPollPost(String(params.id));
+
+    if (!post) {
+      return HttpResponse.json(
+        { detail: '存在しない投稿IDです。' },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(post);
+  }),
+  http.post('http://localhost:8040/api/v1/posts/:id/polls', async ({ params, request }) => {
+    const body = (await request.json()) as {
+      option?: {
+        select_num?: number;
+      };
+    };
+    const selectNum = body.option?.select_num;
+
+    if (typeof selectNum !== 'number') {
+      return HttpResponse.json(
+        { detail: '選択肢が指定されていません。' },
+        { status: 400 },
+      );
+    }
+
+    const result = voteMockPollPost(String(params.id), selectNum);
+
+    if (result.status !== 201) {
+      return HttpResponse.json(
+        { detail: result.message ?? '投票に失敗しました。' },
+        { status: result.status },
+      );
+    }
+
+    return HttpResponse.json(result.response, { status: 201 });
+  }),
+  http.delete('http://localhost:8040/api/v1/posts/:id', ({ params }) => {
+    const result = deleteMockPollPost(String(params.id));
+
+    if (result.status === 204) {
+      return new HttpResponse(null, { status: 204 });
+    }
+
+    return HttpResponse.json(
+      { detail: result.message ?? '投稿を削除できませんでした。' },
+      { status: result.status },
+    );
   }),
 ];

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,7 +1,7 @@
 export interface PostOption {
   select_num: number;
   answer: string;
-  votes?: number;
+  votes: number;
 }
 
 export interface Post {
@@ -12,6 +12,23 @@ export interface Post {
   voted: boolean;
   options: PostOption[];
   created_at: string;
+  selected_num: number;
+  total: number;
+}
+
+export interface VoteOption {
+  select_num: number;
+  votes: number;
+}
+
+export interface VotePayload {
+  option: {
+    select_num: number;
+  };
+}
+
+export interface VoteResponse {
+  options: VoteOption[];
   selected_num: number;
   total: number;
 }


### PR DESCRIPTION
## 概要

投票詳細画面を追加し、未投票時の投票実行、投票後/投票済み時の結果表示、作成者向け削除導線を実装しました。

## 変更点

- `/polls/:id` ルートと `PollDetailPage` を追加
- `usePollDetail` で 10 秒 polling の詳細取得を追加
- `useVote` で楽観的更新付きの投票 mutation を追加
- MSW に poll detail / vote / delete の stateful mock を追加
- `poll-detail-page.test.tsx` を追加し、未投票・投票後・投票済み・ローディング・エラー・削除ボタンを検証

## 背景 / 目的

投票体験の中心となる「投票する → 結果を見る」導線を React 側で成立させるためです。結果表示は即時反映と polling の両方で破綻しない形に寄せています。

## 影響範囲

- 対象画面: 投票詳細画面 (`/polls/:id`)
- 対象ユーザー: ログイン済みの投票参加ユーザー / 投稿作成者
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: 新規画面のためなし
- After:

#### 未投票

![未投票状態](https://files.catbox.moe/mcw5jq.png)

#### 投票後

![投票後状態](https://files.catbox.moe/i5k5jy.png)

#### 投票済み

![投票済み状態](https://files.catbox.moe/js8uar.png)

#### 作成者本人

![作成者本人状態](https://files.catbox.moe/zbne7x.png)

### 操作動画

- なし

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- Linear: https://linear.app/shappar/issue/SHA-30/投票詳細投票実行画面

## 補足

- reviewer向け確認手順:
  - `cd frontend && npm install`
  - `npm run test:run`
  - `npm run build`
- 必要な環境変数やログイン方法:
  - 通常の frontend 環境変数
  - ローカル mock でのスクリーンショット確認時は一時 proof edit + `VITE_ENABLE_MOCKS=true npm run dev -- --host 127.0.0.1 --port 4173` を使用（コミット対象外）
