### PR TITLE
SHA-41: mock Google login when VITE_ENABLE_MOCKS is enabled

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -13,11 +13,7 @@ const authStoreMocks = vi.hoisted(() => {
 });
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return { auth: mockAuth };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 vi.mock('@/stores/auth-store', () => ({
   useAuthStore: (selector: (state: { initAuthListener: () => () => void }) => unknown) =>
     selector({ initAuthListener: authStoreMocks.initAuthListener }),

--- a/frontend/src/__tests__/router.test.tsx
+++ b/frontend/src/__tests__/router.test.tsx
@@ -19,13 +19,7 @@ const authStoreState = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return {
-    auth: mockAuth,
-  };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 vi.mock('@/stores/auth-store', () => ({
   useAuthStore: (
     selector: (state: {

--- a/frontend/src/components/__tests__/header.test.tsx
+++ b/frontend/src/components/__tests__/header.test.tsx
@@ -1,13 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return {
-    auth: mockAuth,
-  };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 
 const authStoreState = vi.hoisted(() => ({
   authUser: {
@@ -30,7 +24,7 @@ vi.mock('@/stores/auth-store', () => ({
   ) => selector(authStoreState),
 }));
 
-import { signOut } from 'firebase/auth';
+import { signOut } from '@/lib/firebase-auth';
 import { Header } from '@/components/header';
 import { render, screen, userEvent, waitFor } from '@/test/test-utils';
 

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { signOut } from 'firebase/auth';
 import { Link } from 'react-router-dom';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -11,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { auth } from '@/lib/firebase';
+import { auth, signOut } from '@/lib/firebase-auth';
 import { useAuthStore } from '@/stores/auth-store';
 
 function getAvatarFallback(name: string) {

--- a/frontend/src/features/auth/__tests__/use-auth-mutation.test.ts
+++ b/frontend/src/features/auth/__tests__/use-auth-mutation.test.ts
@@ -1,18 +1,14 @@
 import { act } from '@testing-library/react';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
 import { HttpResponse, http } from 'msw';
 import { createElement } from 'react';
 import type { PropsWithChildren } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 
-  return { auth: mockAuth };
-});
-
+import { getIdToken, type FirebaseUser } from '@/lib/firebase-auth';
 import { useAuthMutation } from '@/features/auth/use-auth-mutation';
 import type { AuthResponse, AuthUser } from '@/features/auth/types';
 import { createQueryClient } from '@/lib/query-client';

--- a/frontend/src/features/auth/use-auth-mutation.ts
+++ b/frontend/src/features/auth/use-auth-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
-import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
 import { extractAuthUser, type AuthResponse } from '@/features/auth/types';
 import { apiClient } from '@/lib/api-client';
+import { getIdToken, type FirebaseUser } from '@/lib/firebase-auth';
 import { useAuthStore } from '@/stores/auth-store';
 
 export function useAuthMutation() {

--- a/frontend/src/hooks/__tests__/use-api-error-handler.test.ts
+++ b/frontend/src/hooks/__tests__/use-api-error-handler.test.ts
@@ -7,11 +7,7 @@ const authStoreState = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return { auth: mockAuth };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>(
     'react-router-dom',

--- a/frontend/src/lib/__tests__/api-client.test.ts
+++ b/frontend/src/lib/__tests__/api-client.test.ts
@@ -1,12 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getIdToken, type User as FirebaseUser } from 'firebase/auth';
+import { getIdToken, type FirebaseUser } from '@/lib/firebase-auth';
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return { auth: mockAuth };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 
 import { ApiError, apiClient } from '@/lib/api-client';
 import { mockAuth, resetFirebaseAuthMocks } from '@/test/mocks/firebase';

--- a/frontend/src/lib/__tests__/query-client.test.ts
+++ b/frontend/src/lib/__tests__/query-client.test.ts
@@ -3,11 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const clearUserMock = vi.hoisted(() => vi.fn());
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return { auth: mockAuth };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 vi.mock('@/stores/auth-store', () => {
   const useAuthStore = Object.assign(
     (selector: (state: { clearUser: () => void }) => unknown) =>

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,5 +1,4 @@
-import { getIdToken } from 'firebase/auth';
-import { auth } from '@/lib/firebase';
+import { auth, getIdToken } from '@/lib/firebase-auth';
 
 const DEFAULT_API_BASE_URL = 'http://localhost:8040';
 

--- a/frontend/src/lib/firebase-auth.test.ts
+++ b/frontend/src/lib/firebase-auth.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { GoogleAuthProvider, mockAuth } = await import('@/test/mocks/firebase');
+
+  return {
+    auth: mockAuth,
+    googleProvider: new GoogleAuthProvider(),
+  };
+});
+
+async function loadFirebaseAuthModule() {
+  return import('@/lib/firebase-auth');
+}
+
+describe('firebase-auth runtime wrapper', () => {
+  beforeEach(async () => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    window.localStorage.clear();
+    const { resetFirebaseAuthMocks } = await import('@/test/mocks/firebase');
+    resetFirebaseAuthMocks();
+  });
+
+  it('creates and clears a mock auth session when VITE_ENABLE_MOCKS=true', async () => {
+    vi.stubEnv('VITE_ENABLE_MOCKS', 'true');
+
+    const firebaseAuth = await loadFirebaseAuthModule();
+    const authStateListener = vi.fn();
+    const unsubscribe = firebaseAuth.onAuthStateChanged(
+      firebaseAuth.auth,
+      authStateListener,
+    );
+
+    expect(authStateListener).toHaveBeenCalledWith(null);
+
+    const credentials = await firebaseAuth.signInWithPopup(
+      firebaseAuth.auth,
+      firebaseAuth.googleProvider,
+    );
+
+    expect(credentials.user).toMatchObject({
+      uid: 'mock-user-123',
+      displayName: 'Shappar User',
+    });
+    expect(firebaseAuth.auth.currentUser).toEqual(credentials.user);
+    expect(window.localStorage.getItem('shappar:mock-auth-session')).toBe(
+      'mock-user-123',
+    );
+    expect(authStateListener).toHaveBeenLastCalledWith(credentials.user);
+    await expect(firebaseAuth.getIdToken(credentials.user)).resolves.toBe(
+      'mock-id-token',
+    );
+
+    await firebaseAuth.signOut(firebaseAuth.auth);
+
+    expect(firebaseAuth.auth.currentUser).toBeNull();
+    expect(window.localStorage.getItem('shappar:mock-auth-session')).toBeNull();
+    expect(authStateListener).toHaveBeenLastCalledWith(null);
+    unsubscribe();
+  });
+
+  it('restores a mock auth session from localStorage', async () => {
+    vi.stubEnv('VITE_ENABLE_MOCKS', 'true');
+    window.localStorage.setItem('shappar:mock-auth-session', 'mock-user-123');
+
+    const firebaseAuth = await loadFirebaseAuthModule();
+
+    expect(firebaseAuth.auth.currentUser).toMatchObject({
+      uid: 'mock-user-123',
+      displayName: 'Shappar User',
+    });
+  });
+
+  it('delegates to Firebase auth when mocks are disabled', async () => {
+    const authModule = await import('firebase/auth');
+    const firebaseAuth = await loadFirebaseAuthModule();
+    const unsubscribe = vi.fn();
+    const authStateListener = vi.fn();
+    const firebaseUser = { uid: 'firebase-user-123' } as never;
+
+    vi.mocked(authModule.onAuthStateChanged).mockImplementationOnce(
+      (_auth, callback) => {
+        (callback as (user: null) => void)(null);
+        return unsubscribe;
+      },
+    );
+    vi.mocked(authModule.signInWithPopup).mockResolvedValueOnce({
+      user: firebaseUser,
+    } as never);
+    vi.mocked(authModule.getIdToken).mockResolvedValueOnce('valid-id-token');
+    vi.mocked(authModule.signOut).mockResolvedValueOnce(undefined);
+
+    expect(
+      firebaseAuth.onAuthStateChanged(firebaseAuth.auth, authStateListener),
+    ).toBe(unsubscribe);
+
+    await expect(
+      firebaseAuth.signInWithPopup(
+        firebaseAuth.auth,
+        firebaseAuth.googleProvider,
+      ),
+    ).resolves.toEqual({
+      user: firebaseUser,
+    });
+    await expect(firebaseAuth.getIdToken(firebaseUser)).resolves.toBe(
+      'valid-id-token',
+    );
+    await expect(firebaseAuth.signOut(firebaseAuth.auth)).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/lib/firebase-auth.ts
+++ b/frontend/src/lib/firebase-auth.ts
@@ -1,0 +1,124 @@
+import {
+  getIdToken as getFirebaseIdToken,
+  onAuthStateChanged as onFirebaseAuthStateChanged,
+  signInWithPopup as signInWithFirebasePopup,
+  signOut as signOutFromFirebase,
+  type GoogleAuthProvider,
+  type User as FirebaseUser,
+  type UserCredential,
+} from 'firebase/auth';
+import { auth as firebaseAuth, googleProvider } from '@/lib/firebase';
+
+const MOCK_AUTH_ID_TOKEN = 'mock-id-token';
+const MOCK_AUTH_STORAGE_KEY = 'shappar:mock-auth-session';
+const MOCK_FIREBASE_USER = {
+  displayName: 'Shappar User',
+  email: 'mock-user@example.com',
+  photoURL: 'https://example.com/icon.png',
+  uid: 'mock-user-123',
+} as FirebaseUser;
+
+type AuthClient = {
+  currentUser: FirebaseUser | null;
+};
+
+type AuthStateListener = (user: FirebaseUser | null) => void;
+
+export const isMockAuthEnabled =
+  import.meta.env.VITE_ENABLE_MOCKS === 'true';
+
+function getStoredMockSession() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.localStorage.getItem(MOCK_AUTH_STORAGE_KEY);
+}
+
+function persistMockSession(isAuthenticated: boolean) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (isAuthenticated) {
+    window.localStorage.setItem(MOCK_AUTH_STORAGE_KEY, MOCK_FIREBASE_USER.uid);
+    return;
+  }
+
+  window.localStorage.removeItem(MOCK_AUTH_STORAGE_KEY);
+}
+
+const mockAuth: AuthClient = {
+  currentUser:
+    isMockAuthEnabled && getStoredMockSession() ? MOCK_FIREBASE_USER : null,
+};
+
+const mockAuthListeners = new Set<AuthStateListener>();
+
+function notifyMockAuthListeners() {
+  for (const listener of mockAuthListeners) {
+    listener(mockAuth.currentUser);
+  }
+}
+
+export const auth: AuthClient = isMockAuthEnabled ? mockAuth : firebaseAuth;
+export { googleProvider };
+export type { FirebaseUser };
+
+export async function signInWithPopup(
+  authClient: AuthClient,
+  provider: GoogleAuthProvider,
+) {
+  if (!isMockAuthEnabled) {
+    return signInWithFirebasePopup(
+      authClient as typeof firebaseAuth,
+      provider,
+    );
+  }
+
+  mockAuth.currentUser = MOCK_FIREBASE_USER;
+  persistMockSession(true);
+  notifyMockAuthListeners();
+
+  return {
+    user: MOCK_FIREBASE_USER,
+  } as UserCredential;
+}
+
+export function onAuthStateChanged(
+  authClient: AuthClient,
+  listener: AuthStateListener,
+) {
+  if (!isMockAuthEnabled) {
+    return onFirebaseAuthStateChanged(
+      authClient as typeof firebaseAuth,
+      listener,
+    );
+  }
+
+  mockAuthListeners.add(listener);
+  listener(authClient.currentUser);
+
+  return () => {
+    mockAuthListeners.delete(listener);
+  };
+}
+
+export function getIdToken(user: FirebaseUser) {
+  if (!isMockAuthEnabled) {
+    return getFirebaseIdToken(user);
+  }
+
+  return Promise.resolve(MOCK_AUTH_ID_TOKEN);
+}
+
+export async function signOut(authClient: AuthClient) {
+  if (!isMockAuthEnabled) {
+    await signOutFromFirebase(authClient as typeof firebaseAuth);
+    return;
+  }
+
+  mockAuth.currentUser = null;
+  persistMockSession(false);
+  notifyMockAuthListeners();
+}

--- a/frontend/src/pages/__tests__/create-poll-page.test.tsx
+++ b/frontend/src/pages/__tests__/create-poll-page.test.tsx
@@ -1,5 +1,4 @@
 import { QueryClientProvider } from '@tanstack/react-query';
-import { getIdToken } from 'firebase/auth';
 import { HttpResponse, http } from 'msw';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,14 +19,7 @@ const authStoreState = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { GoogleAuthProvider, mockAuth } = await import('@/test/mocks/firebase');
-
-  return {
-    auth: mockAuth,
-    googleProvider: new GoogleAuthProvider(),
-  };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 vi.mock('@/stores/auth-store', () => ({
   useAuthStore: (
     selector: (state: typeof authStoreState) => unknown,
@@ -35,6 +27,7 @@ vi.mock('@/stores/auth-store', () => ({
 }));
 
 import { appRoutes } from '@/router';
+import { getIdToken } from '@/lib/firebase-auth';
 import { createQueryClient } from '@/lib/query-client';
 import { createMockPollPost, resetMockPollPosts } from '@/mocks/poll-data';
 import { server } from '@/test/mocks/server';

--- a/frontend/src/pages/__tests__/login-page.test.tsx
+++ b/frontend/src/pages/__tests__/login-page.test.tsx
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { signInWithPopup } from 'firebase/auth';
+import {
+  auth,
+  googleProvider,
+  signInWithPopup,
+} from '@/lib/firebase-auth';
 
 const authMutationMocks = vi.hoisted(() => ({
   isPending: false,
@@ -7,22 +11,13 @@ const authMutationMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { GoogleAuthProvider, mockAuth } = await import('@/test/mocks/firebase');
-
-  return {
-    auth: mockAuth,
-    googleProvider: new GoogleAuthProvider(),
-  };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 vi.mock('@/features/auth/use-auth-mutation', () => ({
   useAuthMutation: () => ({
     isPending: authMutationMocks.isPending,
     mutateAsync: authMutationMocks.mutateAsync,
   }),
 }));
-
-import { auth, googleProvider } from '@/lib/firebase';
 import { LoginPage } from '@/pages/login-page';
 import { render, screen, userEvent, waitFor } from '@/test/test-utils';
 

--- a/frontend/src/pages/__tests__/poll-detail-page.test.tsx
+++ b/frontend/src/pages/__tests__/poll-detail-page.test.tsx
@@ -4,13 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return {
-    auth: mockAuth,
-  };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 
 import { createQueryClient } from '@/lib/query-client';
 import {

--- a/frontend/src/pages/__tests__/timeline-page.test.tsx
+++ b/frontend/src/pages/__tests__/timeline-page.test.tsx
@@ -13,13 +13,7 @@ import {
 } from 'vitest';
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return {
-    auth: mockAuth,
-  };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 
 import { TimelinePage } from '@/pages/TimelinePage';
 import type { Post } from '@/types/api';

--- a/frontend/src/pages/login-page.tsx
+++ b/frontend/src/pages/login-page.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { signInWithPopup } from 'firebase/auth';
 import { ErrorDisplay } from '@/components/error-display';
 import { Button } from '@/components/ui/button';
 import {
@@ -11,7 +10,7 @@ import {
 } from '@/components/ui/card';
 import { useAuthMutation } from '@/features/auth/use-auth-mutation';
 import { ApiError } from '@/lib/api-client';
-import { auth, googleProvider } from '@/lib/firebase';
+import { auth, googleProvider, signInWithPopup } from '@/lib/firebase-auth';
 
 const DEFAULT_LOGIN_ERROR_MESSAGE =
   'Google ログインに失敗しました。時間をおいて再度お試しください。';

--- a/frontend/src/stores/__tests__/auth-store.test.ts
+++ b/frontend/src/stores/__tests__/auth-store.test.ts
@@ -2,11 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { User as FirebaseUser } from 'firebase/auth';
 
 vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
-vi.mock('@/lib/firebase', async () => {
-  const { mockAuth } = await import('@/test/mocks/firebase');
-
-  return { auth: mockAuth };
-});
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
 
 async function loadAuthStore() {
   return import('@/stores/auth-store');
@@ -112,8 +108,7 @@ describe('auth store', () => {
 
   it('registers the Firebase auth listener and returns its unsubscribe handle', async () => {
     const { useAuthStore } = await loadAuthStore();
-    const { onAuthStateChanged } = await import('firebase/auth');
-    const { auth } = await import('@/lib/firebase');
+    const { onAuthStateChanged, auth } = await import('@/lib/firebase-auth');
     const unsubscribe = vi.fn();
 
     vi.mocked(onAuthStateChanged).mockImplementationOnce((_auth, callback) => {
@@ -133,7 +128,7 @@ describe('auth store', () => {
 
   it('stores the Firebase user when the auth listener reports a login', async () => {
     const { useAuthStore } = await loadAuthStore();
-    const { auth } = await import('@/lib/firebase');
+    const { auth } = await import('@/lib/firebase-auth');
     const user = createMockUser({
       uid: 'firebase-user',
       email: 'firebase@example.com',

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -1,7 +1,10 @@
 import { create } from 'zustand';
-import { onAuthStateChanged, type User as FirebaseUser } from 'firebase/auth';
 import type { AuthUser } from '@/features/auth/types';
-import { auth } from '@/lib/firebase';
+import {
+  auth,
+  onAuthStateChanged,
+  type FirebaseUser,
+} from '@/lib/firebase-auth';
 
 export interface AuthState {
   firebaseUser: FirebaseUser | null;

--- a/frontend/src/test/mocks/firebase-auth.ts
+++ b/frontend/src/test/mocks/firebase-auth.ts
@@ -1,0 +1,15 @@
+export {
+  getIdToken,
+  GoogleAuthProvider,
+  mockAuth,
+  onAuthStateChanged,
+  resetFirebaseAuthMocks,
+  signInWithPopup,
+  signOut,
+} from '@/test/mocks/firebase';
+
+import { GoogleAuthProvider, mockAuth } from '@/test/mocks/firebase';
+
+export const auth = mockAuth;
+export const googleProvider = new GoogleAuthProvider();
+export const isMockAuthEnabled = false;


### PR DESCRIPTION
## 概要

`VITE_ENABLE_MOCKS=true` の dev server でも Google ログインが成功するようにし、proof edit なしで protected routes を browser QA できるようにしました。

## 変更点

- `frontend/src/lib/firebase-auth.ts` を追加し、mock mode 用の sign-in / auth listener / ID token / sign-out wrapper を実装
- `/login`、auth store、API client、header の auth entrypoint を wrapper 経由へ統一
- mock auth session を localStorage に保持し、reload や直接遷移でも `/create` などの protected route を継続検証できるようにした
- auth wrapper 向けテストを追加し、既存の auth 関連テストを shared wrapper mock ベースへ更新

## 背景 / 目的

- MSW で `/api/v1/auth` はモック済みだったが、runtime の Firebase popup auth だけが実環境のままで `Google ログインに失敗しました。時間をおいて再度お試しください。` が出ていた
- protected routes の dogfood を local proof edit なしで継続できる状態に戻す必要があった

## 影響範囲

- 対象画面: `/login`, `/`, `/create` と auth state を使う共通導線
- 対象ユーザー: `VITE_ENABLE_MOCKS=true` で frontend を runtime QA / dogfood する開発者
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: `VITE_ENABLE_MOCKS=true` でも `/login` の `Google でログイン` 押下後に失敗 alert が表示される
- After: 同条件でログイン成功し、alert なしで protected route を表示できる

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [x] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- SHA-41
- https://linear.app/shappar/issue/SHA-41/frontend-vite-enable-mocks-でも-google-ログインが失敗して-protected-routes

## 補足

- reviewer向け確認手順:
  1. `cd frontend`
  2. `set -a; source .env.default; export VITE_ENABLE_MOCKS=true; npm run dev -- --host 127.0.0.1 --port 4173`
  3. `http://127.0.0.1:4173/create` を開き、`/login` へ飛ばされることを確認
  4. `Google でログイン` を押し、失敗 alert が出ず `/` に遷移することを確認
  5. `/create` を開き、`質問` フィールドが表示されることを確認
- 必要な環境変数やログイン方法: `frontend/.env.default` を読み込んだ上で `VITE_ENABLE_MOCKS=true` を付与して起動
