### PR TITLE
feat: add poll share flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-toast": "^1.2.15",
         "@tanstack/react-query": "^5.96.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2584,6 +2585,96 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -2712,6 +2803,70 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-toast": "^1.2.15",
     "@tanstack/react-query": "^5.96.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { ErrorBoundary } from '@/components/error-boundary';
+import { Toaster } from '@/components/ui/toaster';
+import { ToastContextProvider } from '@/hooks/use-toast';
 import { router } from '@/router';
 import { queryClient } from '@/lib/query-client';
 import { useAuthStore } from '@/stores/auth-store';
@@ -15,9 +17,12 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary>
-        <RouterProvider router={router} />
-      </ErrorBoundary>
+      <ToastContextProvider>
+        <ErrorBoundary>
+          <RouterProvider router={router} />
+          <Toaster />
+        </ErrorBoundary>
+      </ToastContextProvider>
     </QueryClientProvider>
   );
 }

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+
+type ShareButtonProps = {
+  question: string;
+  url: string;
+};
+
+function ShareIcon() {
+  return (
+    <svg aria-hidden="true" className="size-4" viewBox="0 0 24 24">
+      <path
+        d="M14 4h6v6m-7 7 7-7M20 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h4"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+export function ShareButton({ question, url }: ShareButtonProps) {
+  const { toast } = useToast();
+  const shareText = `${question} - Shappar で投票しよう！`;
+
+  async function handleShare() {
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share({
+          title: question,
+          text: shareText,
+          url,
+        });
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+      }
+
+      return;
+    }
+
+    await navigator.clipboard.writeText(url);
+    toast({
+      title: 'リンクをコピーしました',
+      description: 'この投票を貼り付けてシェアできます。',
+    });
+  }
+
+  return (
+    <Button
+      className="gap-2 self-start border-white/60 bg-white/80 text-slate-900 shadow-sm backdrop-blur hover:bg-white"
+      onClick={() => {
+        void handleShare();
+      }}
+      type="button"
+      variant="outline"
+    >
+      <ShareIcon />
+      シェア
+    </Button>
+  );
+}

--- a/frontend/src/components/__tests__/share-button.test.tsx
+++ b/frontend/src/components/__tests__/share-button.test.tsx
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ShareButton } from '@/components/ShareButton';
+import { Toaster } from '@/components/ui/toaster';
+import { ToastContextProvider } from '@/hooks/use-toast';
+import { render, screen, userEvent, waitFor } from '@/test/test-utils';
+
+const question = '次にみんなで撮りに行くならどこ？';
+const url = 'https://example.com/polls/post-unvoted';
+const shareText = `${question} - Shappar で投票しよう！`;
+
+const clipboardWriteText = vi.fn();
+const share = vi.fn();
+
+function renderShareButton() {
+  return render(
+    <ToastContextProvider>
+      <ShareButton question={question} url={url} />
+      <Toaster />
+    </ToastContextProvider>,
+  );
+}
+
+describe('ShareButton', () => {
+  beforeEach(() => {
+    share.mockReset();
+    clipboardWriteText.mockReset();
+    clipboardWriteText.mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: clipboardWriteText,
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the share button', () => {
+    renderShareButton();
+
+    expect(screen.getByRole('button', { name: 'シェア' })).toBeInTheDocument();
+  });
+
+  it('calls navigator.share when Web Share API is available', async () => {
+    share.mockResolvedValueOnce(undefined);
+
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      writable: true,
+      value: share,
+    });
+
+    renderShareButton();
+
+    await userEvent.click(screen.getByRole('button', { name: 'シェア' }));
+
+    await waitFor(() => {
+      expect(share).toHaveBeenCalledWith({
+        title: question,
+        text: shareText,
+        url,
+      });
+    });
+    expect(clipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it('copies the poll URL when Web Share API is unavailable', async () => {
+    renderShareButton();
+
+    await userEvent.click(screen.getByRole('button', { name: 'シェア' }));
+
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledWith(url);
+    });
+  });
+
+  it('shows a success toast after copying the poll URL', async () => {
+    renderShareButton();
+
+    await userEvent.click(screen.getByRole('button', { name: 'シェア' }));
+
+    expect(await screen.findByText('リンクをコピーしました')).toBeInTheDocument();
+    expect(
+      screen.getByText('この投票を貼り付けてシェアできます。'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse gap-2 p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:max-w-[420px]',
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-start justify-between gap-3 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-[0_20px_60px_rgba(15,23,42,0.16)] transition-all data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:animate-in data-[state=open]:slide-in-from-top-full sm:data-[state=open]:slide-in-from-bottom-full',
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(toastVariants(), className)}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn('text-sm font-semibold text-slate-950', className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('text-sm leading-6 text-slate-600', className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export { Toast, ToastDescription, ToastProvider, ToastTitle, ToastViewport };

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,0 +1,37 @@
+import {
+  Toast,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from '@/components/ui/toast';
+import { useToast } from '@/hooks/use-toast';
+
+export function Toaster() {
+  const { dismiss, toasts } = useToast();
+
+  return (
+    <ToastProvider swipeDirection="right">
+      {toasts.map((toast) => (
+        <Toast
+          duration={toast.duration ?? 4000}
+          key={toast.id}
+          onOpenChange={(open) => {
+            if (!open) {
+              dismiss(toast.id);
+            }
+          }}
+          open
+        >
+          <div className="grid gap-1">
+            {toast.title ? <ToastTitle>{toast.title}</ToastTitle> : null}
+            {toast.description ? (
+              <ToastDescription>{toast.description}</ToastDescription>
+            ) : null}
+          </div>
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/frontend/src/hooks/use-toast.tsx
+++ b/frontend/src/hooks/use-toast.tsx
@@ -1,0 +1,73 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+
+type ToastRecord = {
+  id: string;
+  title?: string;
+  description?: string;
+  duration?: number;
+};
+
+type ToastInput = Omit<ToastRecord, 'id'>;
+
+type ToastContextValue = {
+  dismiss: (id: string) => void;
+  toast: (input: ToastInput) => string;
+  toasts: ToastRecord[];
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let toastCount = 0;
+
+export function ToastContextProvider({ children }: PropsWithChildren) {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+
+  function dismiss(id: string) {
+    setToasts((currentToasts) =>
+      currentToasts.filter((toast) => toast.id !== id),
+    );
+  }
+
+  function toast(input: ToastInput) {
+    toastCount += 1;
+
+    const id = `toast-${toastCount}`;
+
+    setToasts((currentToasts) => [
+      ...currentToasts,
+      {
+        id,
+        ...input,
+      },
+    ]);
+
+    return id;
+  }
+
+  return (
+    <ToastContext.Provider
+      value={{
+        dismiss,
+        toast,
+        toasts,
+      }}
+    >
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error('useToast must be used within a ToastContextProvider');
+  }
+
+  return context;
+}

--- a/frontend/src/pages/PollDetailPage.tsx
+++ b/frontend/src/pages/PollDetailPage.tsx
@@ -1,7 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ErrorDisplay } from '@/components/error-display';
+import { ShareButton } from '@/components/ShareButton';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { usePollDetail } from '@/hooks/usePollDetail';
@@ -58,6 +59,7 @@ function LoadingState() {
 export function PollDetailPage() {
   const { id = '', pollId = '' } = useParams();
   const postId = pollId || id;
+  const location = useLocation();
   const navigate = useNavigate();
   const authUser = useAuthStore((state) => state.authUser);
   const {
@@ -130,6 +132,7 @@ export function PollDetailPage() {
 
   const isOwner = authUser?.user_id === post.user_id;
   const showResults = post.voted || isOwner;
+  const shareUrl = new URL(location.pathname, window.location.origin).toString();
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-6">
@@ -152,33 +155,36 @@ export function PollDetailPage() {
                   </p>
                 </div>
               </div>
-              {isOwner ? (
-                <Button
-                  className="gap-2 self-start"
-                  disabled={deleteMutation.isPending}
-                  onClick={() => {
-                    deleteMutation.mutate();
-                  }}
-                  type="button"
-                  variant="outline"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="size-4"
-                    viewBox="0 0 24 24"
+              <div className="flex flex-wrap gap-2 self-start">
+                <ShareButton question={post.question} url={shareUrl} />
+                {isOwner ? (
+                  <Button
+                    className="gap-2"
+                    disabled={deleteMutation.isPending}
+                    onClick={() => {
+                      deleteMutation.mutate();
+                    }}
+                    type="button"
+                    variant="outline"
                   >
-                    <path
-                      d="M3 6h18M8 6V4h8v2m-7 3v8m6-8v8M6 6l1 14h10l1-14"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth="1.8"
-                    />
-                  </svg>
-                  {deleteMutation.isPending ? '削除中...' : '削除'}
-                </Button>
-              ) : null}
+                    <svg
+                      aria-hidden="true"
+                      className="size-4"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M3 6h18M8 6V4h8v2m-7 3v8m6-8v8M6 6l1 14h10l1-14"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="1.8"
+                      />
+                    </svg>
+                    {deleteMutation.isPending ? '削除中...' : '削除'}
+                  </Button>
+                ) : null}
+              </div>
             </div>
           </div>
           <CardContent className="space-y-6 p-6">

--- a/frontend/src/pages/__tests__/poll-detail-page.test.tsx
+++ b/frontend/src/pages/__tests__/poll-detail-page.test.tsx
@@ -19,6 +19,8 @@ import {
   resetMockPollPosts,
   voteMockPollPost,
 } from '@/mocks/poll-data';
+import { Toaster } from '@/components/ui/toaster';
+import { ToastContextProvider } from '@/hooks/use-toast';
 import { PollDetailPage } from '@/pages/PollDetailPage';
 import { useAuthStore } from '@/stores/auth-store';
 import { server } from '@/test/mocks/server';
@@ -53,13 +55,16 @@ function renderPollDetailPage(postId: string) {
   });
 
   return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[`/polls/${postId}`]}>
-        <Routes>
-          <Route element={<PollDetailPage />} path="/polls/:pollId" />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>,
+    <ToastContextProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/polls/${postId}`]}>
+          <Routes>
+            <Route element={<PollDetailPage />} path="/polls/:pollId" />
+          </Routes>
+        </MemoryRouter>
+        <Toaster />
+      </QueryClientProvider>
+    </ToastContextProvider>,
   );
 }
 
@@ -91,6 +96,14 @@ describe('PollDetailPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /夜景スポット.*投票する/u }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the share button in the page header', async () => {
+    renderPollDetailPage('post-unvoted');
+
+    expect(
+      await screen.findByRole('button', { name: 'シェア' }),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -10,6 +10,8 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import { Toaster } from '@/components/ui/toaster';
+import { ToastContextProvider } from '@/hooks/use-toast';
 import type { ComponentProps, PropsWithChildren, ReactElement } from 'react';
 
 type ExtendedRenderOptions = Omit<RenderOptions, 'wrapper'> & {
@@ -24,14 +26,19 @@ function renderWithProviders(
   const { initialEntries, initialIndex, ...renderOptions } = options;
 
   function Wrapper({ children }: PropsWithChildren) {
-    if (!initialEntries) {
-      return <>{children}</>;
-    }
-
-    return (
+    const content = initialEntries ? (
       <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
         {children}
       </MemoryRouter>
+    ) : (
+      children
+    );
+
+    return (
+      <ToastContextProvider>
+        {content}
+        <Toaster />
+      </ToastContextProvider>
     );
   }
 


### PR DESCRIPTION
## 概要

投票詳細画面にシェアボタンを追加し、Web Share API と URL コピー fallback を実装しました。

## 変更点

- `ShareButton` を追加し、`navigator.share` 対応環境ではシェアシートを起動
- 非対応環境では `navigator.clipboard.writeText` で URL をコピーし、toast で成功通知を表示
- shadcn-style の toast primitives / toaster / hook を追加して `App` に組み込み
- 投票詳細画面と共有 UI のテストを追加し、既存テスト wrapper でも toast provider を使うよう調整

## 背景 / 目的

- 投票詳細からそのまま共有できる導線を追加して拡散しやすくするため
- デスクトップ fallback でも無音コピーにせず、ユーザーに成功フィードバックを返すため

## 影響範囲

- 対象画面: 投票詳細画面
- 対象ユーザー: 投票詳細を閲覧してシェアするユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

#### Before

![投票詳細画面のシェアボタン表示](https://files.catbox.moe/5ydiqa.png)

#### After

![シェア押下後のコピー成功トースト表示](https://files.catbox.moe/riujzv.png)

### 操作動画

- なし

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- Linear: SHA-31

## 補足

- reviewer向け確認手順:
  - `cd frontend && npm run test:run`
  - `cd frontend && npm run build`
  - `cd frontend && VITE_ENABLE_MOCKS=true npm run dev`
  - `http://127.0.0.1:4174/polls/post-unvoted` 相当の投票詳細画面でシェアボタンを押し、デスクトップではコピー成功 toast が出ることを確認
- 必要な環境変数やログイン方法:
  - 通常動作では既存の Firebase 設定を利用
  - PR 用スクリーンショット取得時は headless Chromium の clipboard 権限制約があるため、ブラウザ上で `navigator.clipboard.writeText` を一時 stub して toast 表示だけを確認
