### PR TITLE
プロフィール表示画面を追加

### DIFF
--- a/frontend/src/__tests__/router.test.tsx
+++ b/frontend/src/__tests__/router.test.tsx
@@ -50,6 +50,14 @@ vi.mock('@/pages/not-found-page', () => ({
   NotFoundPage: () => <h1>Mock Not Found Page</h1>,
 }));
 
+vi.mock('@/pages/ProfileEditPage', () => ({
+  ProfileEditPage: () => <h1>Mock Profile Edit Page</h1>,
+}));
+
+vi.mock('@/pages/ProfilePage', () => ({
+  ProfilePage: () => <h1>Mock Profile Page</h1>,
+}));
+
 function renderRouter(pathname: string) {
   const router = createMemoryRouter(appRoutes, {
     initialEntries: [pathname],
@@ -101,6 +109,30 @@ describe('app router', () => {
     expect(
       screen.getByRole('heading', {
         name: 'Mock Not Found Page',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('routes authenticated users on /profile/:userId to the profile page', () => {
+    authStoreState.isAuthenticated = true;
+
+    renderRouter('/profile/user-1');
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Mock Profile Page',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('routes authenticated users on /profile/edit to the static profile edit page', () => {
+    authStoreState.isAuthenticated = true;
+
+    renderRouter('/profile/edit');
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Mock Profile Edit Page',
       }),
     ).toBeInTheDocument();
   });

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { User, UserPostsResponse, UserProfile } from '@/types/api';
+
+export function userQueryKey(userId: string) {
+  return ['user-profile', userId] as const;
+}
+
+async function fetchUserProfile(userId: string): Promise<UserProfile> {
+  const [user, postedResponse, votedResponse] = await Promise.all([
+    apiClient.get<User>(`/api/v1/users/${userId}`),
+    apiClient.get<UserPostsResponse>(`/api/v1/users/${userId}/posted`),
+    apiClient.get<UserPostsResponse>(`/api/v1/users/${userId}/voted`),
+  ]);
+
+  return {
+    ...user,
+    postedCount: postedResponse.posts.length,
+    votedCount: votedResponse.posts.length,
+  };
+}
+
+export function useUser(userId: string) {
+  return useQuery({
+    queryKey: userQueryKey(userId),
+    queryFn: () => fetchUserProfile(userId),
+    enabled: Boolean(userId),
+  });
+}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { postHandlers } from '@/mocks/handlers/posts';
+import { userHandlers } from '@/mocks/handlers/users';
 import { MOCK_AUTH_USER_ID } from '@/mocks/poll-data';
 
 const mockAuthUser = {
@@ -25,4 +26,5 @@ export const handlers = [
     return HttpResponse.json({ status: 'ok' });
   }),
   ...postHandlers,
+  ...userHandlers,
 ];

--- a/frontend/src/mocks/handlers/users.ts
+++ b/frontend/src/mocks/handlers/users.ts
@@ -1,0 +1,120 @@
+import { HttpResponse, http } from 'msw';
+import { MOCK_AUTH_USER_ID } from '@/mocks/poll-data';
+import type { Post, User } from '@/types/api';
+
+const API_BASE_URL = 'http://localhost:8040';
+
+type MockUserRecord = {
+  profile: User;
+  posted: Post[];
+  voted: Post[];
+};
+
+function createMockPost(userId: string, postId: string, question: string): Post {
+  return {
+    post_id: postId,
+    user_id: userId,
+    iconimage: 'https://example.com/post-icon.png',
+    question,
+    voted: true,
+    options: [
+      {
+        select_num: 0,
+        answer: '海辺',
+        votes: 3,
+      },
+      {
+        select_num: 1,
+        answer: '街歩き',
+        votes: 2,
+      },
+    ],
+    created_at: '2026-04-02T10:00:00.000Z',
+    selected_num: 0,
+    total: 5,
+  };
+}
+
+const mockUsers: Record<string, MockUserRecord> = {
+  [MOCK_AUTH_USER_ID]: {
+    profile: {
+      unique_id: 'unique-user-123',
+      user_id: MOCK_AUTH_USER_ID,
+      name: 'Shappar User',
+      introduction: 'I love taking pictures with friends.',
+      iconimage: 'https://example.com/icon.png',
+      homeimage: 'https://example.com/home.png',
+    },
+    posted: [
+      createMockPost(MOCK_AUTH_USER_ID, 'user-post-1', '次の撮影テーマは？'),
+      createMockPost(MOCK_AUTH_USER_ID, 'user-post-2', '一番好きなレンズは？'),
+      createMockPost(MOCK_AUTH_USER_ID, 'user-post-3', '朝と夜、どちらを撮る？'),
+    ],
+    voted: [
+      createMockPost('creator-001', 'voted-post-1', '旅行先で撮りたい景色は？'),
+      createMockPost('creator-002', 'voted-post-2', '次の現像スタイルは？'),
+      createMockPost('creator-003', 'voted-post-3', '休日に撮るならどこ？'),
+      createMockPost('creator-004', 'voted-post-4', 'ポートレートと風景、どっち派？'),
+    ],
+  },
+  'other-user-456': {
+    profile: {
+      unique_id: 'unique-user-456',
+      user_id: 'other-user-456',
+      name: '別ユーザー',
+      introduction: '街角スナップを集めています。',
+      iconimage: '',
+      homeimage: 'https://example.com/other-home.png',
+    },
+    posted: [
+      createMockPost('other-user-456', 'other-post-1', '今週撮るなら何色？'),
+      createMockPost('other-user-456', 'other-post-2', '次の散歩コースは？'),
+    ],
+    voted: [
+      createMockPost('creator-010', 'other-voted-1', '好きな時間帯は？'),
+      createMockPost('creator-011', 'other-voted-2', '次の撮影場所は？'),
+      createMockPost('creator-012', 'other-voted-3', '現像の好みは？'),
+    ],
+  },
+};
+
+function getUserRecord(userId: string) {
+  return mockUsers[userId] ?? null;
+}
+
+function notFoundResponse() {
+  return HttpResponse.json(
+    { detail: '存在しないユーザーです。' },
+    { status: 404 },
+  );
+}
+
+export const userHandlers = [
+  http.get(`${API_BASE_URL}/api/v1/users/:userId`, ({ params }) => {
+    const user = getUserRecord(String(params.userId));
+
+    if (!user) {
+      return notFoundResponse();
+    }
+
+    return HttpResponse.json(user.profile);
+  }),
+  http.get(`${API_BASE_URL}/api/v1/users/:userId/posted`, ({ params }) => {
+    const user = getUserRecord(String(params.userId));
+
+    if (!user) {
+      return notFoundResponse();
+    }
+
+    return HttpResponse.json({ posts: user.posted });
+  }),
+  http.get(`${API_BASE_URL}/api/v1/users/:userId/voted`, ({ params }) => {
+    const user = getUserRecord(String(params.userId));
+
+    if (!user) {
+      return notFoundResponse();
+    }
+
+    return HttpResponse.json({ posts: user.voted });
+  }),
+];

--- a/frontend/src/pages/ProfileEditPage.tsx
+++ b/frontend/src/pages/ProfileEditPage.tsx
@@ -1,0 +1,34 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export function ProfileEditPage() {
+  return (
+    <section className="mx-auto w-full max-w-3xl">
+      <Card className="border-slate-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+        <CardHeader className="space-y-3">
+          <div className="space-y-1">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+              Profile
+            </p>
+            <CardTitle className="text-3xl text-slate-950">
+              プロフィール編集
+            </CardTitle>
+          </div>
+          <CardDescription className="text-base leading-7 text-slate-600">
+            この画面は後続フェーズで実装予定です。現在はプロフィール導線を先に接続しています。
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm leading-6 text-slate-600">
+            編集機能の本体は未実装ですが、プロフィール画面の「編集」ボタンからこの導線に遷移できます。
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,159 @@
+import { Link, useParams } from 'react-router-dom';
+import { ErrorDisplay } from '@/components/error-display';
+import {
+  Avatar,
+  AvatarFallback,
+} from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { getApiErrorMessage } from '@/hooks/use-api-error-handler';
+import { useUser } from '@/hooks/useUser';
+import { useAuthStore } from '@/stores/auth-store';
+
+function getAvatarFallback(label: string) {
+  const trimmedLabel = label.trim();
+
+  if (!trimmedLabel) {
+    return 'U';
+  }
+
+  return trimmedLabel.slice(0, 1).toUpperCase();
+}
+
+function LoadingState() {
+  return (
+    <main className="flex min-h-[60vh] items-center justify-center px-4 py-10">
+      <div
+        aria-live="polite"
+        className="space-y-4 text-center"
+        role="status"
+      >
+        <div className="mx-auto size-12 animate-spin rounded-full border-4 border-slate-200 border-t-sky-600" />
+        <div className="space-y-1">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+            Profile
+          </p>
+          <p className="text-base text-slate-600">
+            プロフィールを読み込んでいます...
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+interface ProfileMetricProps {
+  label: string;
+  value: string;
+}
+
+function ProfileMetric({ label, value }: ProfileMetricProps) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
+      <dt className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+        {label}
+      </dt>
+      <dd className="mt-2 text-2xl font-semibold text-slate-950">{value}</dd>
+    </div>
+  );
+}
+
+export function ProfilePage() {
+  const { userId = '' } = useParams();
+  const authUserId = useAuthStore((state) => state.authUser?.user_id ?? '');
+  const { data: user, error, isLoading, refetch } = useUser(userId);
+
+  if (!userId) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <ErrorDisplay message="ユーザー ID が見つかりませんでした。" />
+      </main>
+    );
+  }
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!user) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <ErrorDisplay
+          message={getApiErrorMessage(error)}
+          onRetry={() => {
+            void refetch();
+          }}
+        />
+      </main>
+    );
+  }
+
+  const isOwnProfile = authUserId === user.user_id;
+  const displayName = user.name.trim() || user.user_id;
+  const description =
+    user.introduction.trim() || '自己紹介はまだ設定されていません。';
+  const iconImage = user.iconimage.trim() || undefined;
+
+  return (
+    <section className="mx-auto w-full max-w-4xl">
+      <Card className="overflow-hidden border-slate-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+        <div className="bg-[linear-gradient(135deg,_rgba(14,165,233,0.16),_rgba(226,232,240,0.85))] px-6 py-8">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <Avatar className="size-24 border-4 border-white/90 shadow-lg shadow-slate-950/10">
+                {iconImage ? (
+                  <img
+                    alt={`${displayName}のアイコン`}
+                    className="aspect-square h-full w-full object-cover"
+                    src={iconImage}
+                  />
+                ) : null}
+                <AvatarFallback className="bg-slate-200 text-3xl font-semibold text-slate-700">
+                  {getAvatarFallback(displayName)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+                    Profile
+                  </p>
+                  <h1 className="text-3xl font-semibold text-slate-950">
+                    {displayName}
+                  </h1>
+                  <p className="text-sm font-medium text-slate-500">
+                    @{user.user_id}
+                  </p>
+                </div>
+                <p className="max-w-2xl text-base leading-7 text-slate-600">
+                  {description}
+                </p>
+              </div>
+            </div>
+            <div className="flex min-h-10 min-w-32 items-start justify-start lg:justify-end">
+              {isOwnProfile ? (
+                <Button asChild className="min-w-32">
+                  <Link to="/profile/edit">編集</Link>
+                </Button>
+              ) : (
+                <Button
+                  className="min-w-32"
+                  disabled
+                  type="button"
+                  variant="outline"
+                >
+                  フォロー
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+        <CardContent className="space-y-6 p-6">
+          <dl className="grid gap-4 sm:grid-cols-2">
+            <ProfileMetric label="投稿数" value={`${user.postedCount}件`} />
+            <ProfileMetric label="投票数" value={`${user.votedCount}件`} />
+          </dl>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/pages/__tests__/profile-page.test.tsx
+++ b/frontend/src/pages/__tests__/profile-page.test.tsx
@@ -1,0 +1,284 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, delay, http } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return {
+    auth: mockAuth,
+  };
+});
+
+import { createQueryClient } from '@/lib/query-client';
+import { MOCK_AUTH_USER_ID } from '@/mocks/poll-data';
+import { ProfilePage } from '@/pages/ProfilePage';
+import { useAuthStore } from '@/stores/auth-store';
+import { server } from '@/test/mocks/server';
+import { render, screen } from '@/test/test-utils';
+import type { Post, User } from '@/types/api';
+
+const API_BASE_URL = 'http://localhost:8040';
+
+function createAuthUser(
+  overrides: Partial<NonNullable<ReturnType<typeof useAuthStore.getState>['authUser']>> = {},
+) {
+  return {
+    unique_id: 'unique-user-123',
+    user_id: MOCK_AUTH_USER_ID,
+    name: 'Shappar User',
+    introduction: '写真仲間と投票を楽しむユーザー',
+    iconimage: 'https://example.com/icon.png',
+    homeimage: 'https://example.com/home.png',
+    ...overrides,
+  };
+}
+
+function createProfile(overrides: Partial<User> = {}): User {
+  return {
+    unique_id: 'unique-user-123',
+    user_id: MOCK_AUTH_USER_ID,
+    name: 'Shappar User',
+    introduction: '写真仲間と投票を楽しむユーザー',
+    iconimage: 'https://example.com/icon.png',
+    homeimage: 'https://example.com/home.png',
+    ...overrides,
+  };
+}
+
+function createPosts(count: number, userId: string): Post[] {
+  return Array.from({ length: count }, (_, index) => ({
+    post_id: `${userId}-post-${index + 1}`,
+    user_id: userId,
+    iconimage: 'https://example.com/post-icon.png',
+    question: `写真テーマ ${index + 1}`,
+    voted: true,
+    options: [
+      {
+        select_num: 0,
+        answer: '海辺',
+        votes: 3,
+      },
+      {
+        select_num: 1,
+        answer: '街歩き',
+        votes: 2,
+      },
+    ],
+    created_at: `2026-04-${String(index + 1).padStart(2, '0')}T10:00:00.000Z`,
+    selected_num: 0,
+    total: 5,
+  }));
+}
+
+function mockProfileRequests({
+  user = createProfile(),
+  postedCount = 4,
+  votedCount = 9,
+}: {
+  user?: User;
+  postedCount?: number;
+  votedCount?: number;
+} = {}) {
+  server.use(
+    http.get(`${API_BASE_URL}/api/v1/users/:userId`, ({ params }) => {
+      if (String(params.userId) !== user.user_id) {
+        return HttpResponse.json(
+          { detail: '存在しないユーザーです。' },
+          { status: 404 },
+        );
+      }
+
+      return HttpResponse.json(user);
+    }),
+    http.get(`${API_BASE_URL}/api/v1/users/:userId/posted`, ({ params }) => {
+      if (String(params.userId) !== user.user_id) {
+        return HttpResponse.json(
+          { detail: '存在しないユーザーです。' },
+          { status: 404 },
+        );
+      }
+
+      return HttpResponse.json({
+        posts: createPosts(postedCount, user.user_id),
+      });
+    }),
+    http.get(`${API_BASE_URL}/api/v1/users/:userId/voted`, ({ params }) => {
+      if (String(params.userId) !== user.user_id) {
+        return HttpResponse.json(
+          { detail: '存在しないユーザーです。' },
+          { status: 404 },
+        );
+      }
+
+      return HttpResponse.json({
+        posts: createPosts(votedCount, `voted-${user.user_id}`),
+      });
+    }),
+  );
+}
+
+function renderProfilePage(userId: string) {
+  const queryClient = createQueryClient();
+  const defaultOptions = queryClient.getDefaultOptions();
+
+  queryClient.setDefaultOptions({
+    queries: {
+      ...defaultOptions.queries,
+      retry: false,
+    },
+    mutations: {
+      ...defaultOptions.mutations,
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/profile/${userId}`]}>
+        <Routes>
+          <Route element={<ProfilePage />} path="/profile/:userId" />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      firebaseUser: null,
+      authUser: createAuthUser(),
+      isAuthenticated: true,
+      isLoading: false,
+    });
+  });
+
+  it('renders the profile page with the user name, icon, description, and counts', async () => {
+    mockProfileRequests({
+      user: createProfile({
+        name: '山田 花子',
+        introduction: 'フィルム写真と街歩きが好きです。',
+        iconimage: 'https://example.com/hanako.png',
+      }),
+      postedCount: 12,
+      votedCount: 34,
+    });
+
+    renderProfilePage(MOCK_AUTH_USER_ID);
+
+    expect(screen.getByText('プロフィールを読み込んでいます...')).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole('heading', {
+        name: '山田 花子',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', {
+        name: '山田 花子のアイコン',
+      }),
+    ).toHaveAttribute('src', 'https://example.com/hanako.png');
+    expect(screen.getByText('フィルム写真と街歩きが好きです。')).toBeInTheDocument();
+    expect(screen.getByText('投稿数')).toBeInTheDocument();
+    expect(screen.getByText('12件')).toBeInTheDocument();
+    expect(screen.getByText('投票数')).toBeInTheDocument();
+    expect(screen.getByText('34件')).toBeInTheDocument();
+  });
+
+  it('shows a default avatar when the user has not set an icon image', async () => {
+    mockProfileRequests({
+      user: createProfile({
+        name: '佐藤 圭',
+        iconimage: '',
+      }),
+    });
+
+    renderProfilePage(MOCK_AUTH_USER_ID);
+
+    expect(
+      await screen.findByRole('heading', {
+        name: '佐藤 圭',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('img', {
+        name: '佐藤 圭のアイコン',
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('佐')).toBeInTheDocument();
+  });
+
+  it('shows the edit button when viewing the signed-in user profile', async () => {
+    mockProfileRequests();
+
+    renderProfilePage(MOCK_AUTH_USER_ID);
+
+    const editLink = await screen.findByRole('link', {
+      name: '編集',
+    });
+
+    expect(editLink).toHaveAttribute('href', '/profile/edit');
+  });
+
+  it('does not show the edit button when viewing another user profile', async () => {
+    mockProfileRequests({
+      user: createProfile({
+        user_id: 'other-user-456',
+        name: '別ユーザー',
+      }),
+    });
+
+    renderProfilePage('other-user-456');
+
+    expect(
+      await screen.findByRole('heading', {
+        name: '別ユーザー',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: '編集',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'フォロー',
+      }),
+    ).toBeDisabled();
+  });
+
+  it('shows the loading state while the profile query is pending', () => {
+    mockProfileRequests();
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/users/:userId`, async () => {
+        await delay(200);
+
+        return HttpResponse.json(createProfile());
+      }),
+    );
+
+    renderProfilePage(MOCK_AUTH_USER_ID);
+
+    expect(screen.getByText('プロフィールを読み込んでいます...')).toBeInTheDocument();
+  });
+
+  it('shows the error state when the profile query fails', async () => {
+    mockProfileRequests();
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/users/:userId`, () =>
+        HttpResponse.json(
+          { detail: 'ユーザー情報の取得に失敗しました。' },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    renderProfilePage(MOCK_AUTH_USER_ID);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'サーバーエラーが発生しました',
+    );
+  });
+});

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,6 +6,8 @@ import { HomePage } from '@/pages/home-page';
 import { LoginPage } from '@/pages/login-page';
 import { NotFoundPage } from '@/pages/not-found-page';
 import { PollDetailPage } from '@/pages/PollDetailPage';
+import { ProfileEditPage } from '@/pages/ProfileEditPage';
+import { ProfilePage } from '@/pages/ProfilePage';
 
 export const appRoutes: RouteObject[] = [
   {
@@ -40,6 +42,14 @@ export const appRoutes: RouteObject[] = [
           {
             path: 'posts/:postId',
             element: <PollDetailPage />,
+          },
+          {
+            path: 'profile/edit',
+            element: <ProfileEditPage />,
+          },
+          {
+            path: 'profile/:userId',
+            element: <ProfilePage />,
           },
         ],
       },

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from 'msw';
 import { postHandlers } from '@/mocks/handlers/posts';
+import { userHandlers } from '@/mocks/handlers/users';
 import { MOCK_AUTH_USER_ID } from '@/mocks/poll-data';
 
 const mockAuthUser = {
@@ -25,4 +26,5 @@ export const handlers = [
     return HttpResponse.json({ status: 'ok' });
   }),
   ...postHandlers,
+  ...userHandlers,
 ];

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -29,6 +29,28 @@ export interface Post {
   total: number;
 }
 
+export interface User {
+  unique_id?: string;
+  user_id: string;
+  name: string;
+  introduction: string;
+  homeimage?: string;
+  homeImage?: string;
+  iconimage: string;
+  followers?: number;
+  follow?: number;
+  followed?: boolean;
+}
+
+export interface UserPostsResponse {
+  posts: Post[];
+}
+
+export interface UserProfile extends User {
+  postedCount: number;
+  votedCount: number;
+}
+
 export interface VoteOption {
   select_num: number;
   votes: number;
@@ -44,15 +66,4 @@ export interface VoteResponse {
   options: VoteOption[];
   selected_num: number;
   total: number;
-}
-
-export interface User {
-  user_id: string;
-  name: string;
-  introduction: string;
-  homeImage: string;
-  iconimage: string;
-  followers: number;
-  follow: number;
-  followed: boolean;
 }


### PR DESCRIPTION
## 概要

- 認証済みユーザー向けのプロフィール表示画面を追加
- 自分のプロフィールでは「編集」、他ユーザーではフォローボタン用プレースホルダーを表示
- `/profile/:userId` 導線、profile 用 query hook、MSW モック、テストを追加

## 変更点

- `ProfilePage` を追加し、アイコン・名前・説明文・投稿数・投票数を表示
- `useUser` で `/api/v1/users/:userId` と `/posted` `/voted` をまとめて取得して count を合成
- `/profile/edit` の静的 route と一時プレースホルダー画面を追加して dynamic route 衝突を回避
- user handler / router test / page test を追加

## 背景 / 目的

- Linear `SHA-36` のプロフィール表示画面を実装するため
- repo 内の user schema には投稿数 / 投票数が含まれないため、既存 endpoint から count を導出して UI 要件を満たすため

## 影響範囲

- 対象画面: `frontend` のプロフィール画面、router、MSW
- 対象ユーザー: 認証済みユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: `/profile/:userId` route 未実装で `NotFoundPage`
- After:
  - self: ![self profile](https://files.catbox.moe/9bnmuq.png)
  - other: ![other profile](https://files.catbox.moe/z06bqx.png)
  - loading: ![loading profile](https://files.catbox.moe/yvsw3s.png)

### 操作動画

- なし

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- Linear: SHA-36

## 補足

- reviewer向け確認手順:
  - `cd frontend && npm run test:run`
  - `cd frontend && npm run build`
  - 自分プロフィール: `/profile/user-123`
  - 他ユーザープロフィール: `/profile/other-user-456`
- 必要な環境変数やログイン方法:
  - runtime 検証では `VITE_FIREBASE_*` 未設定だと `auth/invalid-api-key` で app が落ちるため、ローカルではダミー値を与えて起動
  - スクリーンショット取得時は auth / API を一時的にブラウザ側で seed し、スクリーンショット自体は repo に commit していない

