### PR TITLE
SHA-38: add My Page profile tabs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toast": "^1.2.15",
         "@tanstack/react-query": "^5.96.1",
         "class-variance-authority": "^0.7.1",
@@ -2571,6 +2572,92 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@tanstack/react-query": "^5.96.1",
     "class-variance-authority": "^0.7.1",

--- a/frontend/src/components/__tests__/header.test.tsx
+++ b/frontend/src/components/__tests__/header.test.tsx
@@ -90,6 +90,24 @@ describe('Header', () => {
     expect(screen.getByText('ログアウト')).toBeInTheDocument();
   });
 
+  it('shows a My Page link in the user menu', async () => {
+    const user = userEvent.setup();
+
+    render(<Header />, { initialEntries: ['/'] });
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'ユーザーメニュー',
+      }),
+    );
+
+    expect(
+      screen.getByRole('menuitem', {
+        name: 'マイページ',
+      }),
+    ).toHaveAttribute('href', '/profile');
+  });
+
   it('calls Firebase signOut when the logout action is clicked', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -92,7 +92,9 @@ export function Header() {
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem disabled>マイページ</DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link to="/profile">マイページ</Link>
+              </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={isSigningOut}
                 onSelect={() => void handleSignOut()}

--- a/frontend/src/components/poll-card.tsx
+++ b/frontend/src/components/poll-card.tsx
@@ -1,0 +1,90 @@
+import { Link } from 'react-router-dom';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import type { Post } from '@/types/api';
+
+function formatCreatedAt(createdAt: string) {
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(createdAt));
+}
+
+export function PollCard({ post }: { post: Post }) {
+  return (
+    <Link
+      aria-label={post.question}
+      className="group block"
+      to={`/polls/${post.post_id}`}
+    >
+      <Card className="h-full rounded-[1.75rem] border-slate-200/80 bg-white/95 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-sky-200 group-hover:shadow-[0_24px_60px_rgba(14,116,144,0.12)]">
+        <CardHeader className="gap-4 pb-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-500">
+                <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">
+                  投稿者 {post.user_id}
+                </span>
+                <span>{formatCreatedAt(post.created_at)}</span>
+              </div>
+              <CardTitle className="text-xl leading-8 text-slate-950">
+                {post.question}
+              </CardTitle>
+            </div>
+            {post.voted ? (
+              <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                投票済み
+              </span>
+            ) : null}
+          </div>
+          <CardDescription className="text-sm leading-6 text-slate-600">
+            回答候補を確認して、気になる投票にそのまま参加できます。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl bg-slate-50 px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Choices
+              </p>
+              <p className="mt-2 text-lg font-semibold text-slate-950">
+                選択肢 {post.options.length}件
+              </p>
+            </div>
+            <div className="rounded-2xl bg-slate-50 px-4 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Votes
+              </p>
+              <p className="mt-2 text-lg font-semibold text-slate-950">
+                投票 {post.total}票
+              </p>
+            </div>
+          </div>
+          <ul className="grid gap-2">
+            {post.options.slice(0, 3).map((option) => (
+              <li
+                key={`${post.post_id}-${option.select_num}`}
+                className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-700"
+              >
+                <span>{option.answer}</span>
+                <span className="font-medium text-slate-500">
+                  {post.voted ? `${option.votes ?? 0}票` : '結果は投票後に表示'}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    className={cn(
+      'inline-flex h-auto items-center justify-center rounded-2xl bg-slate-100 p-1 text-slate-500',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    className={cn(
+      'inline-flex items-center justify-center rounded-[1rem] px-4 py-2.5 text-sm font-semibold transition-all',
+      'ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2',
+      'disabled:pointer-events-none disabled:opacity-50',
+      'data-[state=active]:bg-white data-[state=active]:text-slate-950 data-[state=active]:shadow-sm',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    className={cn(
+      'mt-6 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2',
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/frontend/src/hooks/usePostedPolls.ts
+++ b/frontend/src/hooks/usePostedPolls.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { Post } from '@/types/api';
+
+interface UserPollsResponse {
+  posts: Post[];
+}
+
+interface UseUserPollsOptions {
+  enabled?: boolean;
+}
+
+async function fetchPostedPolls(userId: string) {
+  return apiClient.get<UserPollsResponse>(`/api/v1/users/${userId}/posted`);
+}
+
+export function postedPollsQueryKey(userId: string) {
+  return ['posted-polls', userId] as const;
+}
+
+export function usePostedPolls(
+  userId: string,
+  { enabled = true }: UseUserPollsOptions = {},
+) {
+  return useQuery({
+    queryKey: postedPollsQueryKey(userId),
+    queryFn: () => fetchPostedPolls(userId),
+    enabled: enabled && userId.length > 0,
+  });
+}

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { User } from '@/types/api';
+
+interface UseUserProfileOptions {
+  enabled?: boolean;
+}
+
+async function fetchUserProfile(userId: string) {
+  return apiClient.get<User>(`/api/v1/users/${userId}`);
+}
+
+export function userProfileQueryKey(userId: string) {
+  return ['user-basic-profile', userId] as const;
+}
+
+export function useUserProfile(
+  userId: string,
+  { enabled = true }: UseUserProfileOptions = {},
+) {
+  return useQuery({
+    queryKey: userProfileQueryKey(userId),
+    queryFn: () => fetchUserProfile(userId),
+    enabled: enabled && userId.length > 0,
+  });
+}

--- a/frontend/src/hooks/useVotedPolls.ts
+++ b/frontend/src/hooks/useVotedPolls.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/lib/api-client';
+import type { Post } from '@/types/api';
+
+interface UserPollsResponse {
+  posts: Post[];
+}
+
+interface UseUserPollsOptions {
+  enabled?: boolean;
+}
+
+async function fetchVotedPolls(userId: string) {
+  return apiClient.get<UserPollsResponse>(`/api/v1/users/${userId}/voted`);
+}
+
+export function votedPollsQueryKey(userId: string) {
+  return ['voted-polls', userId] as const;
+}
+
+export function useVotedPolls(
+  userId: string,
+  { enabled = true }: UseUserPollsOptions = {},
+) {
+  return useQuery({
+    queryKey: votedPollsQueryKey(userId),
+    queryFn: () => fetchVotedPolls(userId),
+    enabled: enabled && userId.length > 0,
+  });
+}

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { ErrorDisplay } from '@/components/error-display';
+import { PollCard } from '@/components/poll-card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { usePostedPolls } from '@/hooks/usePostedPolls';
+import { useVotedPolls } from '@/hooks/useVotedPolls';
+import type { Post } from '@/types/api';
+
+type MyPageTab = 'posted' | 'voted';
+
+function LoadingState({ label }: { label: string }) {
+  return (
+    <div
+      aria-live="polite"
+      className="flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-[2rem] border border-dashed border-slate-300 bg-white/70 text-slate-700"
+      role="status"
+    >
+      <div className="size-10 animate-spin rounded-full border-4 border-slate-200 border-t-sky-500" />
+      <p className="text-sm font-medium">{label}</p>
+    </div>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex min-h-[280px] flex-col items-center justify-center rounded-[2rem] border border-dashed border-slate-300 bg-white/70 px-6 text-center">
+      <p className="text-sm font-semibold uppercase tracking-[0.24em] text-sky-700">
+        My Page
+      </p>
+      <h3 className="mt-3 text-2xl font-semibold text-slate-950">{title}</h3>
+      <p className="mt-2 max-w-md text-sm leading-6 text-slate-600">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+function PollGrid({ posts }: { posts: Post[] }) {
+  return (
+    <div className="grid gap-5 lg:grid-cols-2">
+      {posts.map((post) => (
+        <PollCard key={post.post_id} post={post} />
+      ))}
+    </div>
+  );
+}
+
+function PollListContent({
+  emptyDescription,
+  emptyTitle,
+  errorMessage,
+  isError,
+  isLoading,
+  loadingLabel,
+  onRetry,
+  posts,
+}: {
+  emptyDescription: string;
+  emptyTitle: string;
+  errorMessage: string;
+  isError: boolean;
+  isLoading: boolean;
+  loadingLabel: string;
+  onRetry: () => void;
+  posts: Post[];
+}) {
+  if (isLoading) {
+    return <LoadingState label={loadingLabel} />;
+  }
+
+  if (isError) {
+    return <ErrorDisplay message={errorMessage} onRetry={onRetry} />;
+  }
+
+  if (posts.length === 0) {
+    return <EmptyState description={emptyDescription} title={emptyTitle} />;
+  }
+
+  return <PollGrid posts={posts} />;
+}
+
+export function MyPage({
+  isOwnPage,
+  userId,
+}: {
+  isOwnPage: boolean;
+  userId: string;
+}) {
+  const [activeTab, setActiveTab] = useState<MyPageTab>('posted');
+  const postedQuery = usePostedPolls(userId);
+  // Voted history is private and only needs fetching when the user opens that tab.
+  const votedQuery = useVotedPolls(userId, {
+    enabled: isOwnPage && activeTab === 'voted',
+  });
+  const postedPosts = postedQuery.data?.posts ?? [];
+  const votedPosts = votedQuery.data?.posts ?? [];
+
+  return (
+    <section className="space-y-6">
+      <div className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-sky-700">
+          My Page
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              投稿と投票の履歴
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              自分の活動を振り返ったり、気になるユーザーの投稿一覧を確認できます。
+            </p>
+          </div>
+          <div className="rounded-2xl bg-sky-50 px-4 py-3 text-sm text-sky-900">
+            {activeTab === 'posted'
+              ? `投稿 ${postedPosts.length} 件`
+              : `投票履歴 ${votedPosts.length} 件`}
+          </div>
+        </div>
+      </div>
+
+      <Tabs
+        className="space-y-0"
+        onValueChange={(value) => setActiveTab(value as MyPageTab)}
+        value={activeTab}
+      >
+        <TabsList
+          className={`grid w-full max-w-md ${
+            isOwnPage ? 'grid-cols-2' : 'grid-cols-1'
+          }`}
+        >
+          <TabsTrigger value="posted">投稿した投票</TabsTrigger>
+          {isOwnPage ? <TabsTrigger value="voted">投票した履歴</TabsTrigger> : null}
+        </TabsList>
+
+        <TabsContent value="posted">
+          <PollListContent
+            emptyDescription="投票を作成すると、ここに自分の投稿が並びます。"
+            emptyTitle="まだ投稿した投票はありません。"
+            errorMessage={
+              postedQuery.error instanceof Error
+                ? postedQuery.error.message
+                : '投稿した投票の取得に失敗しました。'
+            }
+            isError={postedQuery.isError}
+            isLoading={postedQuery.isLoading}
+            loadingLabel="投稿した投票を読み込み中..."
+            onRetry={() => {
+              void postedQuery.refetch();
+            }}
+            posts={postedPosts}
+          />
+        </TabsContent>
+
+        {isOwnPage ? (
+          <TabsContent value="voted">
+            <PollListContent
+              emptyDescription="投票に参加すると、ここからいつでも履歴を見返せます。"
+              emptyTitle="まだ投票した履歴はありません。"
+              errorMessage={
+                votedQuery.error instanceof Error
+                  ? votedQuery.error.message
+                  : '投票した履歴の取得に失敗しました。'
+              }
+              isError={votedQuery.isError}
+              isLoading={votedQuery.isLoading}
+              loadingLabel="投票した履歴を読み込み中..."
+              onRetry={() => {
+                void votedQuery.refetch();
+              }}
+              posts={votedPosts}
+            />
+          </TabsContent>
+        ) : null}
+      </Tabs>
+    </section>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,11 +1,14 @@
 import { Link, useParams } from 'react-router-dom';
 import { ErrorDisplay } from '@/components/error-display';
+import { MyPage } from '@/pages/MyPage';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { getApiErrorMessage } from '@/hooks/use-api-error-handler';
-import { useUser } from '@/hooks/useUser';
+import { usePostedPolls } from '@/hooks/usePostedPolls';
+import { useUserProfile } from '@/hooks/useUserProfile';
+import { useVotedPolls } from '@/hooks/useVotedPolls';
 import { useAuthStore } from '@/stores/auth-store';
+import type { User } from '@/types/api';
 
 function getAvatarFallback(label: string) {
   const trimmedLabel = label.trim();
@@ -17,14 +20,22 @@ function getAvatarFallback(label: string) {
   return trimmedLabel.slice(0, 1).toUpperCase();
 }
 
+function getDisplayName(profile: User) {
+  return profile.name.trim() || profile.user_id;
+}
+
+function getDescription(profile: User) {
+  return profile.introduction.trim() || '自己紹介はまだ設定されていません。';
+}
+
+function getHomeImage(profile: User) {
+  return profile.homeimage?.trim() || profile.homeImage?.trim() || '';
+}
+
 function LoadingState() {
   return (
     <main className="flex min-h-[60vh] items-center justify-center px-4 py-10">
-      <div
-        aria-live="polite"
-        className="space-y-4 text-center"
-        role="status"
-      >
+      <div aria-live="polite" className="space-y-4 text-center" role="status">
         <div className="mx-auto size-12 animate-spin rounded-full border-4 border-slate-200 border-t-sky-600" />
         <div className="space-y-1">
           <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
@@ -39,12 +50,7 @@ function LoadingState() {
   );
 }
 
-interface ProfileMetricProps {
-  label: string;
-  value: string;
-}
-
-function ProfileMetric({ label, value }: ProfileMetricProps) {
+function ProfileMetric({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5">
       <dt className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
@@ -55,102 +61,164 @@ function ProfileMetric({ label, value }: ProfileMetricProps) {
   );
 }
 
-export function ProfilePage() {
-  const { userId = '' } = useParams();
-  const authUserId = useAuthStore((state) => state.authUser?.user_id ?? '');
-  const { data: user, error, isLoading, refetch } = useUser(userId);
+function ProfileHeader({
+  isOwnPage,
+  postedCount,
+  profile,
+  votedCount,
+}: {
+  isOwnPage: boolean;
+  postedCount: number;
+  profile: User;
+  votedCount: number;
+}) {
+  const displayName = getDisplayName(profile);
+  const description = getDescription(profile);
+  const homeImage = getHomeImage(profile);
+  const iconImage = profile.iconimage.trim() || undefined;
 
-  if (!userId) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+      <div
+        className="h-40 bg-[linear-gradient(135deg,_rgba(14,165,233,0.16),_rgba(226,232,240,0.85))] bg-cover bg-center sm:h-48"
+        style={
+          homeImage
+            ? {
+                backgroundImage: `linear-gradient(135deg, rgba(14,165,233,0.16), rgba(226,232,240,0.85)), url(${homeImage})`,
+              }
+            : undefined
+        }
+      />
+      <div className="relative px-6 pb-6 pt-0 sm:px-8">
+        <div className="-mt-12 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+            <Avatar className="size-24 border-4 border-white/90 bg-slate-100 shadow-lg shadow-slate-950/10 sm:size-28">
+              {iconImage ? (
+                <img
+                  alt={`${displayName}のアイコン`}
+                  className="aspect-square h-full w-full object-cover"
+                  src={iconImage}
+                />
+              ) : null}
+              <AvatarFallback className="bg-slate-200 text-3xl font-semibold text-slate-700">
+                {getAvatarFallback(displayName)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="space-y-3 pb-2">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+                  Profile
+                </p>
+                <h1 className="text-3xl font-semibold tracking-tight text-slate-950">
+                  {displayName}
+                </h1>
+                <p className="text-sm font-medium text-slate-500">
+                  @{profile.user_id}
+                </p>
+              </div>
+              <p className="max-w-2xl text-base leading-7 text-slate-600">
+                {description}
+              </p>
+            </div>
+          </div>
+          <div className="flex min-h-10 min-w-32 items-start justify-start lg:justify-end">
+            {isOwnPage ? (
+              <Button asChild className="min-w-32">
+                <Link to="/profile/edit">編集</Link>
+              </Button>
+            ) : (
+              <Button className="min-w-32" disabled type="button" variant="outline">
+                フォロー
+              </Button>
+            )}
+          </div>
+        </div>
+        <dl
+          className={`mt-6 grid gap-4 ${
+            isOwnPage ? 'sm:grid-cols-2' : 'sm:grid-cols-1'
+          }`}
+        >
+          <ProfileMetric label="投稿数" value={`${postedCount}件`} />
+          {isOwnPage ? (
+            <ProfileMetric label="投票数" value={`${votedCount}件`} />
+          ) : null}
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+export function ProfilePage() {
+  const authUser = useAuthStore((state) => state.authUser);
+  const authUserId = authUser?.user_id ?? '';
+  const { userId: paramUserId } = useParams();
+  const resolvedUserId = paramUserId ?? authUserId;
+  const isOwnPage = authUserId.length > 0 && authUserId === resolvedUserId;
+  const shouldLoadRemoteProfile = Boolean(paramUserId && resolvedUserId);
+  const profileQuery = useUserProfile(resolvedUserId, {
+    enabled: shouldLoadRemoteProfile,
+  });
+  const postedQuery = usePostedPolls(resolvedUserId, {
+    enabled: resolvedUserId.length > 0,
+  });
+  const votedQuery = useVotedPolls(resolvedUserId, {
+    enabled: isOwnPage && resolvedUserId.length > 0,
+  });
+
+  if (!resolvedUserId) {
     return (
       <main className="mx-auto max-w-4xl px-4 py-10">
-        <ErrorDisplay message="ユーザー ID が見つかりませんでした。" />
+        <ErrorDisplay message="プロフィールを表示できませんでした。" />
       </main>
     );
   }
 
-  if (isLoading) {
+  if (
+    shouldLoadRemoteProfile &&
+    (profileQuery.isLoading ||
+      postedQuery.isLoading ||
+      (isOwnPage && votedQuery.isLoading))
+  ) {
     return <LoadingState />;
   }
 
-  if (!user) {
+  if (shouldLoadRemoteProfile && profileQuery.isError) {
     return (
       <main className="mx-auto max-w-4xl px-4 py-10">
         <ErrorDisplay
-          message={getApiErrorMessage(error)}
+          message={getApiErrorMessage(profileQuery.error)}
           onRetry={() => {
-            void refetch();
+            void profileQuery.refetch();
           }}
         />
       </main>
     );
   }
 
-  const isOwnProfile = authUserId === user.user_id;
-  const displayName = user.name.trim() || user.user_id;
-  const description =
-    user.introduction.trim() || '自己紹介はまだ設定されていません。';
-  const iconImage = user.iconimage.trim() || undefined;
+  const profile: User | null = shouldLoadRemoteProfile
+    ? profileQuery.data ?? null
+    : authUser;
+
+  if (!profile) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-10">
+        <ErrorDisplay message="プロフィールを表示できませんでした。" />
+      </main>
+    );
+  }
+
+  const postedCount = postedQuery.data?.posts.length ?? 0;
+  const votedCount = isOwnPage ? votedQuery.data?.posts.length ?? 0 : 0;
 
   return (
-    <section className="mx-auto w-full max-w-4xl">
-      <Card className="overflow-hidden border-slate-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
-        <div className="bg-[linear-gradient(135deg,_rgba(14,165,233,0.16),_rgba(226,232,240,0.85))] px-6 py-8">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-              <Avatar className="size-24 border-4 border-white/90 shadow-lg shadow-slate-950/10">
-                {iconImage ? (
-                  <img
-                    alt={`${displayName}のアイコン`}
-                    className="aspect-square h-full w-full object-cover"
-                    src={iconImage}
-                  />
-                ) : null}
-                <AvatarFallback className="bg-slate-200 text-3xl font-semibold text-slate-700">
-                  {getAvatarFallback(displayName)}
-                </AvatarFallback>
-              </Avatar>
-              <div className="space-y-3">
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
-                    Profile
-                  </p>
-                  <h1 className="text-3xl font-semibold text-slate-950">
-                    {displayName}
-                  </h1>
-                  <p className="text-sm font-medium text-slate-500">
-                    @{user.user_id}
-                  </p>
-                </div>
-                <p className="max-w-2xl text-base leading-7 text-slate-600">
-                  {description}
-                </p>
-              </div>
-            </div>
-            <div className="flex min-h-10 min-w-32 items-start justify-start lg:justify-end">
-              {isOwnProfile ? (
-                <Button asChild className="min-w-32">
-                  <Link to="/profile/edit">編集</Link>
-                </Button>
-              ) : (
-                <Button
-                  className="min-w-32"
-                  disabled
-                  type="button"
-                  variant="outline"
-                >
-                  フォロー
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
-        <CardContent className="space-y-6 p-6">
-          <dl className="grid gap-4 sm:grid-cols-2">
-            <ProfileMetric label="投稿数" value={`${user.postedCount}件`} />
-            <ProfileMetric label="投票数" value={`${user.votedCount}件`} />
-          </dl>
-        </CardContent>
-      </Card>
-    </section>
+    <div className="mx-auto w-full max-w-4xl space-y-8">
+      <ProfileHeader
+        isOwnPage={isOwnPage}
+        postedCount={postedCount}
+        profile={profile}
+        votedCount={votedCount}
+      />
+      <MyPage isOwnPage={isOwnPage} userId={resolvedUserId} />
+    </div>
   );
 }

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -1,28 +1,9 @@
 import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
+import { PollCard } from '@/components/poll-card';
 import { ErrorDisplay } from '@/components/error-display';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
 import { usePublicPolls } from '@/hooks/usePublicPolls';
-import type { Post } from '@/types/api';
-
-function formatCreatedAt(createdAt: string) {
-  return new Intl.DateTimeFormat('ja-JP', {
-    timeZone: 'Asia/Tokyo',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(new Date(createdAt));
-}
 
 function LoadingState() {
   return (
@@ -50,75 +31,6 @@ function EmptyState() {
         最初の投票を作成すると、ここに新着の公開投票が並びます。
       </p>
     </div>
-  );
-}
-
-function PollCard({ post }: { post: Post }) {
-  return (
-    <Link
-      aria-label={post.question}
-      className="group block"
-      to={`/polls/${post.post_id}`}
-    >
-      <Card className="h-full rounded-[1.75rem] border-slate-200/80 bg-white/95 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-sky-200 group-hover:shadow-[0_24px_60px_rgba(14,116,144,0.12)]">
-        <CardHeader className="gap-4 pb-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-500">
-                <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">
-                  投稿者 {post.user_id}
-                </span>
-                <span>{formatCreatedAt(post.created_at)}</span>
-              </div>
-              <CardTitle className="text-xl leading-8 text-slate-950">
-                {post.question}
-              </CardTitle>
-            </div>
-            {post.voted ? (
-              <span className="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
-                投票済み
-              </span>
-            ) : null}
-          </div>
-          <CardDescription className="text-sm leading-6 text-slate-600">
-            回答候補を確認して、気になる投票にそのまま参加できます。
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="rounded-2xl bg-slate-50 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Choices
-              </p>
-              <p className="mt-2 text-lg font-semibold text-slate-950">
-                選択肢 {post.options.length}件
-              </p>
-            </div>
-            <div className="rounded-2xl bg-slate-50 px-4 py-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Votes
-              </p>
-              <p className="mt-2 text-lg font-semibold text-slate-950">
-                投票 {post.total}票
-              </p>
-            </div>
-          </div>
-          <ul className="grid gap-2">
-            {post.options.slice(0, 3).map((option) => (
-              <li
-                key={`${post.post_id}-${option.select_num}`}
-                className="flex items-center justify-between rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-700"
-              >
-                <span>{option.answer}</span>
-                <span className="font-medium text-slate-500">
-                  {post.voted ? `${option.votes ?? 0}票` : '結果は投票後に表示'}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
-    </Link>
   );
 }
 

--- a/frontend/src/pages/__tests__/my-page.test.tsx
+++ b/frontend/src/pages/__tests__/my-page.test.tsx
@@ -1,0 +1,314 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HttpResponse, delay, http } from 'msw';
+import { type PropsWithChildren } from 'react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase', async () => {
+  const { mockAuth } = await import('@/test/mocks/firebase');
+
+  return {
+    auth: mockAuth,
+  };
+});
+
+const authStoreState = vi.hoisted(() => ({
+  initAuthListener: vi.fn(() => vi.fn()),
+  authUser: {
+    unique_id: 'unique-user-123',
+    user_id: 'user-123',
+    name: 'Shappar User',
+    introduction: 'I love taking pictures with friends.',
+    iconimage: 'https://example.com/icon.png',
+    homeimage: 'https://example.com/home.png',
+  },
+  clearUser: vi.fn(),
+  isAuthenticated: true,
+  isLoading: false,
+}));
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: (
+    selector: (state: {
+      initAuthListener: () => () => void;
+      authUser: typeof authStoreState.authUser;
+      clearUser: typeof authStoreState.clearUser;
+      isAuthenticated: boolean;
+      isLoading: boolean;
+    }) => unknown,
+  ) => selector(authStoreState),
+}));
+
+import { appRoutes } from '@/router';
+import { server } from '@/test/mocks/server';
+import { render, screen, userEvent } from '@/test/test-utils';
+import type { Post } from '@/types/api';
+
+const API_BASE_URL = 'http://localhost:8040';
+
+function createPost(overrides: Partial<Post> = {}): Post {
+  const optionCount = overrides.options?.length ?? 2;
+
+  return {
+    post_id: 'post-1',
+    user_id: 'user-123',
+    iconimage: 'https://example.com/icon.png',
+    question: '週末はどこで写真を撮る？',
+    voted: false,
+    options: Array.from({ length: optionCount }, (_, index) => ({
+      select_num: index,
+      answer: `選択肢 ${index + 1}`,
+      votes: 10 - index,
+    })),
+    created_at: '2026-04-02T03:15:00.000Z',
+    selected_num: -1,
+    total: 18,
+    ...overrides,
+  };
+}
+
+function mockMyPageApi({
+  userId = 'user-123',
+  userName = 'Shappar User',
+  posted = [],
+  voted = [],
+  responseDelayMs = 0,
+}: {
+  userId?: string;
+  userName?: string;
+  posted?: Post[];
+  voted?: Post[];
+  responseDelayMs?: number;
+} = {}) {
+  server.use(
+    http.get(`${API_BASE_URL}/api/v1/users/:userId`, async ({ params }) => {
+      const resolvedUserId = String(params.userId ?? userId);
+
+      if (responseDelayMs > 0) {
+        await delay(responseDelayMs);
+      }
+
+      return HttpResponse.json({
+        unique_id: `unique-${resolvedUserId}`,
+        user_id: resolvedUserId,
+        name: resolvedUserId === userId ? userName : `${resolvedUserId}さん`,
+        introduction: `${resolvedUserId} introduction`,
+        iconimage: `https://example.com/${resolvedUserId}.png`,
+        homeimage: `https://example.com/${resolvedUserId}-home.png`,
+        followers: 12,
+        follow: 7,
+        followed: resolvedUserId !== userId,
+      });
+    }),
+    http.get(`${API_BASE_URL}/api/v1/users/:userId/posted`, async () => {
+      if (responseDelayMs > 0) {
+        await delay(responseDelayMs);
+      }
+
+      return HttpResponse.json({
+        posts: posted,
+      });
+    }),
+    http.get(`${API_BASE_URL}/api/v1/users/:userId/voted`, async () => {
+      if (responseDelayMs > 0) {
+        await delay(responseDelayMs);
+      }
+
+      return HttpResponse.json({
+        posts: voted,
+      });
+    }),
+  );
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function renderMyPageRoute(pathname: string) {
+  const router = createMemoryRouter(appRoutes, {
+    initialEntries: [pathname],
+  });
+  const Wrapper = createWrapper();
+
+  return render(
+    <Wrapper>
+      <RouterProvider router={router} />
+    </Wrapper>,
+  );
+}
+
+describe('My Page', () => {
+  beforeEach(() => {
+    authStoreState.authUser = {
+      unique_id: 'unique-user-123',
+      user_id: 'user-123',
+      name: 'Shappar User',
+      introduction: 'I love taking pictures with friends.',
+      iconimage: 'https://example.com/icon.png',
+      homeimage: 'https://example.com/home.png',
+    };
+    authStoreState.isAuthenticated = true;
+    authStoreState.isLoading = false;
+    authStoreState.clearUser.mockReset();
+    authStoreState.initAuthListener.mockClear();
+  });
+
+  it('shows the posted and voted tabs on the signed-in user profile', async () => {
+    mockMyPageApi({
+      posted: [createPost({ question: '投稿した投票のタイトル' })],
+      voted: [createPost({ post_id: 'voted-1', question: '投票した履歴のタイトル' })],
+    });
+
+    renderMyPageRoute('/profile');
+
+    expect(
+      await screen.findByRole('tab', { name: '投稿した投票' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('tab', { name: '投票した履歴' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows only the posted tab on another user profile and does not request voted history', async () => {
+    let votedRequests = 0;
+
+    mockMyPageApi({
+      userId: 'creator-002',
+      userName: 'Creator 002',
+      posted: [
+        createPost({
+          post_id: 'posted-1',
+          user_id: 'creator-002',
+          question: '他ユーザーの投稿',
+        }),
+      ],
+    });
+    server.use(
+      http.get(`${API_BASE_URL}/api/v1/users/:userId/voted`, () => {
+        votedRequests += 1;
+
+        return HttpResponse.json({
+          posts: [createPost({ question: 'private history' })],
+        });
+      }),
+    );
+
+    renderMyPageRoute('/profile/creator-002');
+
+    expect(
+      await screen.findByRole('tab', { name: '投稿した投票' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', { name: '投票した履歴' }),
+    ).not.toBeInTheDocument();
+    expect(await screen.findByText('他ユーザーの投稿')).toBeInTheDocument();
+    expect(votedRequests).toBe(0);
+  });
+
+  it('renders the posted poll list on the default tab', async () => {
+    mockMyPageApi({
+      posted: [
+        createPost({
+          post_id: 'posted-1',
+          question: '自分が投稿した投票',
+        }),
+      ],
+      voted: [
+        createPost({
+          post_id: 'voted-1',
+          user_id: 'friend-001',
+          question: '自分が投票した投票',
+          voted: true,
+        }),
+      ],
+    });
+
+    renderMyPageRoute('/profile');
+
+    expect(await screen.findByText('自分が投稿した投票')).toBeInTheDocument();
+    expect(screen.queryByText('自分が投票した投票')).not.toBeInTheDocument();
+  });
+
+  it('renders the voted poll list when the history tab is selected', async () => {
+    const user = userEvent.setup();
+
+    mockMyPageApi({
+      posted: [
+        createPost({
+          post_id: 'posted-1',
+          question: '自分が投稿した投票',
+        }),
+      ],
+      voted: [
+        createPost({
+          post_id: 'voted-1',
+          user_id: 'friend-001',
+          question: '自分が投票した投票',
+          voted: true,
+        }),
+      ],
+    });
+
+    renderMyPageRoute('/profile');
+
+    await screen.findByText('自分が投稿した投票');
+    await user.click(screen.getByRole('tab', { name: '投票した履歴' }));
+
+    expect(await screen.findByText('自分が投票した投票')).toBeInTheDocument();
+  });
+
+  it('shows an empty state message when the selected list is empty', async () => {
+    const user = userEvent.setup();
+
+    mockMyPageApi({
+      posted: [
+        createPost({
+          post_id: 'posted-1',
+          question: '自分が投稿した投票',
+        }),
+      ],
+      voted: [],
+    });
+
+    renderMyPageRoute('/profile');
+
+    await screen.findByText('自分が投稿した投票');
+    await user.click(screen.getByRole('tab', { name: '投票した履歴' }));
+
+    expect(
+      await screen.findByText('まだ投票した履歴はありません。'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a loading state while the page data is loading', async () => {
+    mockMyPageApi({
+      posted: [createPost({ question: '読み込み後に表示される投稿' })],
+      voted: [],
+      responseDelayMs: 200,
+    });
+
+    renderMyPageRoute('/profile');
+
+    expect(screen.getByText('投稿した投票を読み込み中...')).toBeInTheDocument();
+    expect(
+      await screen.findByText('読み込み後に表示される投稿'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/profile-page.tsx
+++ b/frontend/src/pages/profile-page.tsx
@@ -1,0 +1,1 @@
+export { ProfilePage } from '@/pages/ProfilePage';

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -36,16 +36,20 @@ export const appRoutes: RouteObject[] = [
             element: <CreatePage />,
           },
           {
+            path: 'polls/:pollId',
+            element: <PollDetailPage />,
+          },
+          {
+            path: 'profile',
+            element: <ProfilePage />,
+          },
+          {
             path: 'profile/edit',
             element: <ProfileEditPage />,
           },
           {
             path: 'profile/:userId',
             element: <ProfilePage />,
-          },
-          {
-            path: 'polls/:pollId',
-            element: <PollDetailPage />,
           },
           {
             path: 'posts/:postId',


### PR DESCRIPTION
## 概要

プロフィール画面に My Page を追加し、自分の投稿一覧と投票履歴をタブで切り替えて見られるようにしました。あわせて他ユーザー向けプロフィール表示、ヘッダーメニュー導線、プロフィール用の query hook を追加しています。

## 変更点

- `/profile` と `/profile/:userId` を追加し、`ProfilePage` + `MyPage` を実装
- `投稿した投票` / `投票した履歴` のタブ表示と、他ユーザーでは投票履歴を非表示にする分岐を追加
- タイムラインの投票カードを共通 `PollCard` に抽出してプロフィール一覧でも再利用
- `usePostedPolls` / `useVotedPolls` / `useUserProfile` を追加し、最新 `origin/develop` の MSW users mocks と統合
- ヘッダーメニューの `マイページ` を有効化し、My Page / header のテストを追加

## 背景 / 目的

- `SHA-38` の目的である My Page 実装を、現状の frontend には存在しなかったプロフィール画面導線まで含めて完結させるため
- 公開タイムラインとプロフィール上の投票一覧でカード UI を揃え、今後の一覧機能でも再利用できる形にするため
- `#496` 以降の head で GitHub Actions check が生成されなかったため、最新 `origin/develop` から clean history で再試行するため

## 影響範囲

- 対象画面: ヘッダー、プロフィール画面、タイムラインの投票カード
- 対象ユーザー: ログイン済みユーザー、他ユーザーのプロフィールを閲覧するユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: プロフィール導線・プロフィール画面ともに未実装
- After:
  - `frontend/.artifacts/self-profile.png`
  - `frontend/.artifacts/other-user-profile.png`
  - `frontend/.artifacts/empty-profile.png`

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [ ] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- SHA-38

## 補足

- reviewer向け確認手順:
  - `/profile` で自分のページを開き、`投稿した投票` と `投票した履歴` の両タブを確認する
  - `/profile/creator-002` で他ユーザー表示に切り替え、`投稿した投票` のみ表示されることを確認する
  - `/profile/user-empty` で空状態を確認する
- 必要な環境変数やログイン方法:
  - Runtime スクリーンショットは `VITE_ENABLE_MOCKS=true npm run dev -- --host 127.0.0.1 --port 4175` で取得

## 補足メモ

- この PR は `#496` の `a88422b` でも GitHub Actions check が生成されなかったため、最新 `origin/develop` (`851eb96`) から clean history で切り直した再試行 PR です。
- ローカル検証は `32bba6c` で `cd frontend && npm run lint && npm run test:run && npm run build` を実行済みです。
