### PR TITLE
fix: resolve PollDetailPage /posts/:postId param lookup

### DIFF
--- a/frontend/src/pages/PollDetailPage.tsx
+++ b/frontend/src/pages/PollDetailPage.tsx
@@ -57,8 +57,8 @@ function LoadingState() {
 }
 
 export function PollDetailPage() {
-  const { id = '', pollId = '' } = useParams();
-  const postId = pollId || id;
+  const { pollId = '', postId: routePostId = '' } = useParams();
+  const postId = routePostId || pollId;
   const location = useLocation();
   const navigate = useNavigate();
   const authUser = useAuthStore((state) => state.authUser);

--- a/frontend/src/pages/__tests__/poll-detail-page.test.tsx
+++ b/frontend/src/pages/__tests__/poll-detail-page.test.tsx
@@ -34,7 +34,12 @@ function createAuthUser(overrides: Partial<ReturnType<typeof useAuthStore.getSta
   };
 }
 
-function renderPollDetailPage(postId: string) {
+type PollDetailRoute = '/polls/:pollId' | '/posts/:postId';
+
+function renderPollDetailPage(
+  postId: string,
+  routePath: PollDetailRoute = '/polls/:pollId',
+) {
   const queryClient = createQueryClient();
   const defaultOptions = queryClient.getDefaultOptions();
 
@@ -51,9 +56,11 @@ function renderPollDetailPage(postId: string) {
   return render(
     <ToastContextProvider>
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[`/polls/${postId}`]}>
+        <MemoryRouter
+          initialEntries={[routePath.replace(':pollId', postId).replace(':postId', postId)]}
+        >
           <Routes>
-            <Route element={<PollDetailPage />} path="/polls/:pollId" />
+            <Route element={<PollDetailPage />} path={routePath} />
           </Routes>
         </MemoryRouter>
         <Toaster />
@@ -98,6 +105,16 @@ describe('PollDetailPage', () => {
 
     expect(
       await screen.findByRole('button', { name: 'シェア' }),
+    ).toBeInTheDocument();
+  });
+
+  it('supports the /posts/:postId route shape', async () => {
+    renderPollDetailPage('post-unvoted', '/posts/:postId');
+
+    expect(
+      await screen.findByRole('heading', {
+        name: '次にみんなで撮りに行くならどこ？',
+      }),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## 概要

`PollDetailPage` が `/posts/:postId` ルートで `postId` を読めていなかった不具合を修正しました。

## 変更点

- `frontend/src/pages/PollDetailPage.tsx` で `useParams()` から `postId` を読み取るよう修正
- 既存の `/polls/:pollId` 互換を維持するため `pollId` も引き続きフォールバックでサポート
- `frontend/src/pages/__tests__/poll-detail-page.test.tsx` に `/posts/:postId` 回帰テストを追加

## 背景 / 目的

ルーターは `posts/:postId` を定義している一方で、ページ側は `pollId` と `id` しか読んでおらず、`/posts/:postId` で詳細取得が空 ID になっていました。これにより API が 404 になり、詳細画面が表示できませんでした。

## 影響範囲

- 対象画面: 投票詳細ページ (`/posts/:postId`, `/polls/:pollId`)
- 対象ユーザー: 投票詳細ページを共有 URL / 投稿 URL から開くユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: `/posts/post-unvoted` で `投稿 ID が見つかりませんでした。` が表示される
- After: ローカル runtime screenshot を `frontend/.artifacts/sha46-posts-route-runtime.png` に保存済み（チケット指示どおり未コミット）

### 操作動画

- なし

### UI変更なし

- [x] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- Linear: SHA-46

## 補足

- reviewer向け確認手順:
  1. `cd frontend && npm ci`
  2. `VITE_ENABLE_MOCKS=true npm run dev -- --host 127.0.0.1 --port 4173`
  3. `http://127.0.0.1:4173/posts/post-unvoted` を開き、詳細表示と投票を確認
- 必要な環境変数やログイン方法:
  - `VITE_ENABLE_MOCKS=true` を有効化すると mock auth + MSW で確認できます
