### PR TITLE
fix: preserve CreatePollPage option errors after edits

### DIFF
--- a/frontend/src/pages/CreatePollPage.tsx
+++ b/frontend/src/pages/CreatePollPage.tsx
@@ -122,7 +122,9 @@ export function CreatePollPage() {
     setSubmitError(null);
     setErrors((current) => ({
       ...current,
-      options: current.options.map(() => ''),
+      options: current.options.map((error, index) =>
+        index === optionIndex ? '' : error,
+      ),
     }));
   };
 

--- a/frontend/src/pages/__tests__/create-poll-page.test.tsx
+++ b/frontend/src/pages/__tests__/create-poll-page.test.tsx
@@ -171,6 +171,35 @@ describe('CreatePollPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps validation errors on untouched empty options when another option changes', async () => {
+    const user = userEvent.setup();
+
+    renderCreatePollPage();
+
+    await user.type(await screen.findByLabelText('質問'), '次に行きたい場所は？');
+    await user.click(
+      screen.getByRole('button', {
+        name: '選択肢を追加',
+      }),
+    );
+    await user.type(screen.getByLabelText('選択肢 2'), '海');
+    await user.click(
+      screen.getByRole('button', {
+        name: '投票を作成',
+      }),
+    );
+
+    expect(
+      await screen.findAllByText('選択肢を入力してください。'),
+    ).toHaveLength(2);
+
+    await user.type(screen.getByLabelText('選択肢 2'), '辺');
+
+    await waitFor(() => {
+      expect(screen.getAllByText('選択肢を入力してください。')).toHaveLength(2);
+    });
+  });
+
   it('shows a validation error when duplicate options are entered', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## 概要

CreatePollPage で 1 つの選択肢を編集したときに他の選択肢のバリデーションエラーまで消える不具合を修正します。

## 変更点

- `frontend/src/pages/CreatePollPage.tsx` の `handleOptionChange` を修正し、編集中の index のエラーだけをクリアするように変更
- `frontend/src/pages/__tests__/create-poll-page.test.tsx` に、未編集の空選択肢エラーが残り続ける回帰テストを追加

## 背景 / 目的

- failed submit 後に別の選択肢を 1 文字編集するだけで、未修正の空選択肢エラーまで消えていた
- ユーザーが未入力の選択肢を見落としやすく、再送信まで UX が壊れていたため修正

## 影響範囲

- 対象画面: 投票作成画面 (`/create`)
- 対象ユーザー: 投票を新規作成するログインユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: なし
- After: なし

### 操作動画

- なし

### UI変更なし

- [x] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

- Linear: SHA-47

## 補足

- reviewer向け確認手順: `/create` で選択肢を 3 つにし、中央だけ入力して送信後、その中央の選択肢を編集しても両端のエラーが残ることを確認してください。
- 必要な環境変数やログイン方法: 通常の frontend ローカル環境。Codex ではローカル確認時のみ一時的に `ProtectedRoute` を bypass して検証し、変更は revert 済みです。
