### PR TITLE
SHA-48: add coverage for core hooks

### DIFF
--- a/frontend/src/hooks/__tests__/test-helpers.tsx
+++ b/frontend/src/hooks/__tests__/test-helpers.tsx
@@ -1,0 +1,31 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren } from 'react';
+import { createQueryClient } from '@/lib/query-client';
+
+export function createHookTestQueryClient() {
+  const queryClient = createQueryClient();
+  const defaultOptions = queryClient.getDefaultOptions();
+
+  queryClient.setDefaultOptions({
+    queries: {
+      ...defaultOptions.queries,
+      retry: false,
+    },
+    mutations: {
+      ...defaultOptions.mutations,
+      retry: false,
+    },
+  });
+
+  return queryClient;
+}
+
+export function createHookWrapper(queryClient: QueryClient) {
+  return function QueryClientWrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}

--- a/frontend/src/hooks/__tests__/useCreatePoll.test.ts
+++ b/frontend/src/hooks/__tests__/useCreatePoll.test.ts
@@ -38,18 +38,15 @@ describe('useCreatePoll', () => {
     const wrapper = createHookWrapper(queryClient);
     const { result } = renderHook(() => useCreatePoll(), { wrapper });
 
-    let response: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined;
-
     await act(async () => {
-      response = await result.current.mutateAsync({
+      await result.current.mutateAsync({
         question: '次に撮りに行く場所は？',
         options: [{ answer: '海' }, { answer: '山' }],
       });
     });
 
-    expect(response).toEqual({ post_id: expect.any(String) });
-
     await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
       expect(invalidateQueriesSpy).toHaveBeenCalledWith({
         queryKey: ['public-polls'],
       });

--- a/frontend/src/hooks/__tests__/useCreatePoll.test.ts
+++ b/frontend/src/hooks/__tests__/useCreatePoll.test.ts
@@ -1,0 +1,88 @@
+import { act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
+
+import { postedPollsQueryKey } from '@/hooks/usePostedPolls';
+import { userQueryKey } from '@/hooks/useUser';
+import { useCreatePoll } from '@/hooks/useCreatePoll';
+import { MOCK_AUTH_USER_ID, resetMockPollPosts } from '@/mocks/poll-data';
+import { useAuthStore } from '@/stores/auth-store';
+import { renderHook, waitFor } from '@/test/test-utils';
+import { createHookTestQueryClient, createHookWrapper } from './test-helpers';
+
+describe('useCreatePoll', () => {
+  beforeEach(() => {
+    resetMockPollPosts();
+    useAuthStore.setState({
+      authUser: {
+        unique_id: 'unique-user-123',
+        user_id: MOCK_AUTH_USER_ID,
+        name: 'Shappar User',
+        introduction: '写真仲間と投票を楽しむユーザー',
+        iconimage: 'https://example.com/icon.png',
+        homeimage: 'https://example.com/home.png',
+      },
+    });
+  });
+
+  afterEach(() => {
+    useAuthStore.setState({ authUser: null });
+    vi.restoreAllMocks();
+  });
+
+  it('invalidates related caches after a successful poll creation', async () => {
+    const queryClient = createHookTestQueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    let response: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined;
+
+    await act(async () => {
+      response = await result.current.mutateAsync({
+        question: '次に撮りに行く場所は？',
+        options: [{ answer: '海' }, { answer: '山' }],
+      });
+    });
+
+    expect(response).toEqual({ post_id: expect.any(String) });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: ['public-polls'],
+      });
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: postedPollsQueryKey(MOCK_AUTH_USER_ID),
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: userQueryKey(MOCK_AUTH_USER_ID),
+    });
+  });
+
+  it('surfaces validation errors from the API without invalidating caches', async () => {
+    const queryClient = createHookTestQueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    await expect(
+      result.current.mutateAsync({
+        question: '',
+        options: [{ answer: '海' }, { answer: '' }],
+      }),
+    ).rejects.toMatchObject({
+      message: '入力内容を確認してください。',
+      status: 400,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/__tests__/usePollDetail.test.ts
+++ b/frontend/src/hooks/__tests__/usePollDetail.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
+
+import { pollDetailQueryKey, usePollDetail } from '@/hooks/usePollDetail';
+import { resetMockPollPosts } from '@/mocks/poll-data';
+import { renderHook, waitFor } from '@/test/test-utils';
+import { createHookTestQueryClient, createHookWrapper } from './test-helpers';
+
+type PollDetailQueryOptions = {
+  queryKey: ReturnType<typeof pollDetailQueryKey>;
+  refetchInterval?: number;
+  refetchIntervalInBackground?: boolean;
+};
+
+describe('usePollDetail', () => {
+  beforeEach(() => {
+    resetMockPollPosts();
+  });
+
+  it('returns the poll data for the requested post id', async () => {
+    const postId = 'post-unvoted';
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => usePollDetail(postId), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toMatchObject({
+      post_id: postId,
+      question: '次にみんなで撮りに行くならどこ？',
+    });
+    expect(queryClient.getQueryData(pollDetailQueryKey(postId))).toMatchObject({
+      post_id: postId,
+    });
+  });
+
+  it('configures the query to poll every 10 seconds', async () => {
+    const postId = 'post-unvoted';
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+
+    renderHook(() => usePollDetail(postId), { wrapper });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryCache().find({
+          queryKey: pollDetailQueryKey(postId),
+        }),
+      ).toBeDefined();
+    });
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: pollDetailQueryKey(postId),
+    });
+    const queryOptions = query?.options as PollDetailQueryOptions | undefined;
+
+    expect(queryOptions?.queryKey).toEqual(pollDetailQueryKey(postId));
+    expect(queryOptions?.refetchInterval).toBe(10_000);
+    expect(queryOptions?.refetchIntervalInBackground).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/usePublicPolls.test.ts
+++ b/frontend/src/hooks/__tests__/usePublicPolls.test.ts
@@ -1,0 +1,70 @@
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
+
+import { PUBLIC_POLL_PAGE_SIZE, usePublicPolls } from '@/hooks/usePublicPolls';
+import { renderHook, waitFor } from '@/test/test-utils';
+import { createHookTestQueryClient, createHookWrapper } from './test-helpers';
+
+describe('usePublicPolls', () => {
+  it('fetches the first page of public polls', async () => {
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => usePublicPolls(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.pages).toHaveLength(1);
+    expect(result.current.data?.pages[0].posts).toHaveLength(PUBLIC_POLL_PAGE_SIZE);
+    expect(result.current.data?.pages[0].posts[0]?.post_id).toBe('mock-post-1');
+  });
+
+  it('appends the next page when fetchNextPage is called', async () => {
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => usePublicPolls(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+
+    const posts =
+      result.current.data?.pages.flatMap((page) => page.posts) ?? [];
+
+    expect(posts).toHaveLength(12);
+    expect(posts.at(-1)?.post_id).toBe('mock-post-12');
+  });
+
+  it('reports no next page after the terminal page is fetched', async () => {
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => usePublicPolls(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(false);
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useUser.test.ts
+++ b/frontend/src/hooks/__tests__/useUser.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
+
+import { MOCK_AUTH_USER_ID } from '@/mocks/poll-data';
+import { resetMockUsers } from '@/mocks/handlers/users';
+import { renderHook, waitFor } from '@/test/test-utils';
+import { useUser } from '@/hooks/useUser';
+import { createHookTestQueryClient, createHookWrapper } from './test-helpers';
+
+describe('useUser', () => {
+  beforeEach(() => {
+    resetMockUsers();
+  });
+
+  it('returns the user profile and derives counts from posts.length', async () => {
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const { result } = renderHook(() => useUser(MOCK_AUTH_USER_ID), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toMatchObject({
+      user_id: MOCK_AUTH_USER_ID,
+      name: 'Shappar User',
+      postedCount: 3,
+      votedCount: 4,
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useVote.test.ts
+++ b/frontend/src/hooks/__tests__/useVote.test.ts
@@ -1,0 +1,150 @@
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('firebase/auth', () => import('@/test/mocks/firebase'));
+vi.mock('@/lib/firebase-auth', () => import('@/test/mocks/firebase-auth'));
+
+import { pollDetailQueryKey } from '@/hooks/usePollDetail';
+import { useVote } from '@/hooks/useVote';
+import { ApiError, apiClient } from '@/lib/api-client';
+import { getMockPollPost, resetMockPollPosts } from '@/mocks/poll-data';
+import { renderHook, waitFor } from '@/test/test-utils';
+import type { VoteResponse } from '@/types/api';
+import { createHookTestQueryClient, createHookWrapper } from './test-helpers';
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('useVote', () => {
+  beforeEach(() => {
+    resetMockPollPosts();
+    vi.restoreAllMocks();
+  });
+
+  it('optimistically updates the cached poll data before the request resolves', async () => {
+    const postId = 'post-unvoted';
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const deferred = createDeferred<VoteResponse>();
+    const postSpy = vi.spyOn(apiClient, 'post').mockReturnValue(deferred.promise);
+    const initialPost = getMockPollPost(postId);
+
+    queryClient.setQueryData(pollDetailQueryKey(postId), initialPost);
+
+    const { result } = renderHook(() => useVote(postId), { wrapper });
+
+    act(() => {
+      result.current.mutate({ selectNum: 1 });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(pollDetailQueryKey(postId))).toMatchObject({
+        voted: true,
+        selected_num: 1,
+        total: 1,
+      });
+    });
+
+    expect(queryClient.getQueryData(pollDetailQueryKey(postId))).toMatchObject({
+      options: [
+        { select_num: 0, votes: 0 },
+        { select_num: 1, votes: 1 },
+        { select_num: 2, votes: 0 },
+      ],
+    });
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledTimes(1);
+    });
+
+    deferred.resolve({
+      options: [
+        { select_num: 0, votes: 2 },
+        { select_num: 1, votes: 5 },
+        { select_num: 2, votes: 1 },
+      ],
+      selected_num: 1,
+      total: 8,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it('rolls the cached poll data back when the vote request fails', async () => {
+    const postId = 'post-unvoted';
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const deferred = createDeferred<VoteResponse>();
+    const initialPost = getMockPollPost(postId);
+
+    vi.spyOn(apiClient, 'post').mockReturnValue(deferred.promise);
+    queryClient.setQueryData(pollDetailQueryKey(postId), initialPost);
+
+    const { result } = renderHook(() => useVote(postId), { wrapper });
+
+    act(() => {
+      result.current.mutate({ selectNum: 2 });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(pollDetailQueryKey(postId))).toMatchObject({
+        voted: true,
+        selected_num: 2,
+        total: 1,
+      });
+    });
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledTimes(1);
+    });
+
+    deferred.reject(
+      new ApiError('投票に失敗しました。', 500, {
+        detail: '投票に失敗しました。',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(queryClient.getQueryData(pollDetailQueryKey(postId))).toEqual(initialPost);
+  });
+
+  it('does not call the mutation again when the same option is submitted twice', async () => {
+    const postId = 'post-voted';
+    const queryClient = createHookTestQueryClient();
+    const wrapper = createHookWrapper(queryClient);
+    const postSpy = vi.spyOn(apiClient, 'post').mockResolvedValue({
+      options: [],
+      selected_num: 1,
+      total: 8,
+    });
+    const initialPost = getMockPollPost(postId);
+
+    queryClient.setQueryData(pollDetailQueryKey(postId), initialPost);
+
+    const { result } = renderHook(() => useVote(postId), { wrapper });
+
+    act(() => {
+      result.current.mutate({ selectNum: 1 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(pollDetailQueryKey(postId))).toEqual(initialPost);
+  });
+});

--- a/frontend/src/hooks/__tests__/useVote.test.ts
+++ b/frontend/src/hooks/__tests__/useVote.test.ts
@@ -86,8 +86,8 @@ describe('useVote', () => {
     const wrapper = createHookWrapper(queryClient);
     const deferred = createDeferred<VoteResponse>();
     const initialPost = getMockPollPost(postId);
+    const postSpy = vi.spyOn(apiClient, 'post').mockReturnValue(deferred.promise);
 
-    vi.spyOn(apiClient, 'post').mockReturnValue(deferred.promise);
     queryClient.setQueryData(pollDetailQueryKey(postId), initialPost);
 
     const { result } = renderHook(() => useVote(postId), { wrapper });
@@ -105,7 +105,7 @@ describe('useVote', () => {
     });
 
     await waitFor(() => {
-      expect(apiClient.post).toHaveBeenCalledTimes(1);
+      expect(postSpy).toHaveBeenCalledTimes(1);
     });
 
     deferred.reject(

--- a/frontend/src/hooks/useCreatePoll.ts
+++ b/frontend/src/hooks/useCreatePoll.ts
@@ -1,14 +1,35 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { postedPollsQueryKey } from '@/hooks/usePostedPolls';
+import { userQueryKey } from '@/hooks/useUser';
 import { apiClient } from '@/lib/api-client';
-import type {
-  CreatePostRequest,
-  CreatePostResponse,
-} from '@/types/api';
+import { useAuthStore } from '@/stores/auth-store';
+import type { CreatePostRequest, CreatePostResponse } from '@/types/api';
+
+const publicPollsQueryKey = ['public-polls'] as const;
 
 export function useCreatePoll() {
+  const queryClient = useQueryClient();
+  const authUser = useAuthStore((state) => state.authUser);
+
   return useMutation({
     mutationFn: async (payload: CreatePostRequest) => {
       return apiClient.post<CreatePostResponse>('/api/v1/posts', payload);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: publicPollsQueryKey,
+      });
+
+      if (!authUser) {
+        return;
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: postedPollsQueryKey(authUser.user_id),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: userQueryKey(authUser.user_id),
+      });
     },
   });
 }

--- a/frontend/src/hooks/useVote.ts
+++ b/frontend/src/hooks/useVote.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/lib/api-client';
 import { pollDetailQueryKey } from '@/hooks/usePollDetail';
@@ -7,8 +8,17 @@ interface VoteVariables {
   selectNum: number;
 }
 
+interface VoteContext {
+  previousPost?: Post;
+  skipped?: boolean;
+}
+
 function getNormalizedVotes(votes: number | undefined) {
   return Math.max(votes ?? 0, 0);
+}
+
+function isDuplicateVote(post: Post | undefined, selectNum: number) {
+  return post?.voted === true && post.selected_num === selectNum;
 }
 
 function createOptimisticPost(post: Post, selectNum: number): Post {
@@ -45,18 +55,28 @@ function mergeVoteResponse(post: Post, response: VoteResponse) {
 export function useVote(postId: string) {
   const queryClient = useQueryClient();
   const queryKey = pollDetailQueryKey(postId);
+  const skippedSelectNumRef = useRef<number | null>(null);
 
-  return useMutation({
+  return useMutation<VoteResponse | null, unknown, VoteVariables, VoteContext>({
     mutationFn: ({ selectNum }: VoteVariables) =>
-      apiClient.post<VoteResponse>(`/api/v1/posts/${postId}/polls`, {
-        option: {
-          select_num: selectNum,
-        },
-      } satisfies VotePayload),
+      skippedSelectNumRef.current === selectNum
+        ? Promise.resolve(null)
+        : apiClient.post<VoteResponse>(`/api/v1/posts/${postId}/polls`, {
+            option: {
+              select_num: selectNum,
+            },
+          } satisfies VotePayload),
     onMutate: async ({ selectNum }) => {
       await queryClient.cancelQueries({ queryKey });
 
       const previousPost = queryClient.getQueryData<Post>(queryKey);
+
+      if (isDuplicateVote(previousPost, selectNum)) {
+        skippedSelectNumRef.current = selectNum;
+        return { previousPost, skipped: true };
+      }
+
+      skippedSelectNumRef.current = null;
 
       if (previousPost) {
         queryClient.setQueryData(queryKey, createOptimisticPost(previousPost, selectNum));
@@ -65,18 +85,28 @@ export function useVote(postId: string) {
       return { previousPost };
     },
     onError: (_error, _variables, context) => {
-      if (context?.previousPost) {
+      if (!context?.skipped && context?.previousPost) {
         queryClient.setQueryData(queryKey, context.previousPost);
       }
     },
-    onSuccess: (response) => {
+    onSuccess: (response, _variables, context) => {
+      if (context?.skipped || !response) {
+        return;
+      }
+
       const currentPost = queryClient.getQueryData<Post>(queryKey);
 
       if (currentPost) {
         queryClient.setQueryData(queryKey, mergeVoteResponse(currentPost, response));
       }
     },
-    onSettled: () => {
+    onSettled: (_data, _error, _variables, context) => {
+      skippedSelectNumRef.current = null;
+
+      if (context?.skipped) {
+        return;
+      }
+
       void queryClient.invalidateQueries({ queryKey });
     },
   });


### PR DESCRIPTION
## What changed
- add dedicated hook tests for `useVote`, `usePublicPolls`, `usePollDetail`, `useUser`, and `useCreatePoll`
- add a shared React Query hook test wrapper to keep the new suites focused
- align `useVote` duplicate-vote handling and `useCreatePoll` cache invalidation with the tested acceptance criteria

## Why
SHA-48 called out these hooks as untested, with `useVote` specifically missing coverage for the most complex optimistic update and rollback path.

## Impact
The core polling hooks now have direct regression coverage for optimistic updates, pagination, polling configuration, derived user counts, and create-poll mutation behavior.

## Root cause
The codebase had page-level coverage around these flows, but the hooks themselves had no focused tests. Adding direct hook tests also exposed two small behavior gaps in `useVote` and `useCreatePoll`.

## Validation
- `npm run test:run`
- `npm run build`
