### PR TITLE
[SEC] Guard firebase mock auth behind DEV

### DIFF
--- a/frontend/src/lib/firebase-auth.test.ts
+++ b/frontend/src/lib/firebase-auth.test.ts
@@ -24,6 +24,7 @@ describe('firebase-auth runtime wrapper', () => {
   });
 
   it('creates and clears a mock auth session when VITE_ENABLE_MOCKS=true', async () => {
+    vi.stubEnv('DEV', true);
     vi.stubEnv('VITE_ENABLE_MOCKS', 'true');
 
     const firebaseAuth = await loadFirebaseAuthModule();
@@ -62,6 +63,7 @@ describe('firebase-auth runtime wrapper', () => {
   });
 
   it('restores a mock auth session from localStorage', async () => {
+    vi.stubEnv('DEV', true);
     vi.stubEnv('VITE_ENABLE_MOCKS', 'true');
     window.localStorage.setItem('shappar:mock-auth-session', 'mock-user-123');
 
@@ -71,6 +73,30 @@ describe('firebase-auth runtime wrapper', () => {
       uid: 'mock-user-123',
       displayName: 'Shappar User',
     });
+  });
+
+  it('disables mock auth outside DEV even when VITE_ENABLE_MOCKS=true', async () => {
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('VITE_ENABLE_MOCKS', 'true');
+
+    const authModule = await import('firebase/auth');
+    const firebaseUser = { uid: 'firebase-user-123' } as never;
+    vi.mocked(authModule.signInWithPopup).mockResolvedValueOnce({
+      user: firebaseUser,
+    } as never);
+
+    const firebaseAuth = await loadFirebaseAuthModule();
+
+    expect(firebaseAuth.isMockAuthEnabled).toBe(false);
+    await expect(
+      firebaseAuth.signInWithPopup(
+        firebaseAuth.auth,
+        firebaseAuth.googleProvider,
+      ),
+    ).resolves.toEqual({
+      user: firebaseUser,
+    });
+    expect(window.localStorage.getItem('shappar:mock-auth-session')).toBeNull();
   });
 
   it('delegates to Firebase auth when mocks are disabled', async () => {

--- a/frontend/src/lib/firebase-auth.ts
+++ b/frontend/src/lib/firebase-auth.ts
@@ -25,7 +25,7 @@ type AuthClient = {
 type AuthStateListener = (user: FirebaseUser | null) => void;
 
 export const isMockAuthEnabled =
-  import.meta.env.VITE_ENABLE_MOCKS === 'true';
+  import.meta.env.DEV && import.meta.env.VITE_ENABLE_MOCKS === 'true';
 
 function getStoredMockSession() {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
## 概要

`frontend/src/lib/firebase-auth.ts` の mock auth 有効条件を `import.meta.env.DEV` 付きにし、production build では `VITE_ENABLE_MOCKS=true` でも mock auth が有効化されないようにします。

## 変更点

- `isMockAuthEnabled` を `import.meta.env.DEV && import.meta.env.VITE_ENABLE_MOCKS === 'true'` に変更
- `frontend/src/lib/firebase-auth.test.ts` に `DEV=false` かつ `VITE_ENABLE_MOCKS=true` の回帰テストを追加
- 既存の mock-auth 有効系テストで `DEV=true` を明示して意図を固定

## 背景 / 目的

- 本番サーバーや CI の環境変数誤設定だけで mock auth が有効になるリスクを潰すため
- production / development の境界条件をテストで継続的に担保するため

## 影響範囲

- 対象画面: ログイン導線を含む Firebase Auth 利用箇所全体
- 対象ユーザー: mock auth を使う開発者、本番環境の全ユーザー
- 破壊的変更の有無: なし

## スクリーンショット

### UI変更あり

- Before: なし
- After: なし

### 操作動画

- 任意。動きがある変更は GIF / mp4 を添付

### UI変更なし

- [x] UI変更なし

## 確認項目

- [x] ローカルで対象画面を確認
- [x] 主要導線を一通り操作
- [x] `frontend` に変更がある場合は `build` 実行

## 関連issue

close #SHA-45

## 補足

- reviewer向け確認手順:
  - `frontend/src/lib/firebase-auth.ts` の `isMockAuthEnabled` が `DEV` ガード付きになっていること
  - `frontend/src/lib/firebase-auth.test.ts` の production 回帰テストを確認すること
  - `VITE_ENABLE_MOCKS=true` build の preview で `localStorage['shappar:mock-auth-session']='mock-user-123'` を入れても `/login` に残ること
- 必要な環境変数やログイン方法:
  - preview runtime 確認時は `.env.development` の Firebase 値を export して build 済み
